### PR TITLE
Add PG18 documentdb-local image support

### DIFF
--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -37,6 +37,7 @@ jobs:
   build-and-push:
     name: Build and Push Images
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
         include:

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -67,7 +67,7 @@ jobs:
         echo "documentdb_version=$DOCUMENTDB_VERSION" >> $GITHUB_OUTPUT
     - name: Build Debian Package
       run: |
-        DEB_BUILD_OPTIONS=nocheck ./packaging/build_packages.sh --os deb13 --pg ${{ matrix.pg_version }} --output-dir downloaded-artifacts
+        ./packaging/build_packages.sh --os deb13 --pg ${{ matrix.pg_version }} --output-dir downloaded-artifacts
         ls -R downloaded-artifacts
     - name: Login to GHCR
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -67,7 +67,7 @@ jobs:
         echo "documentdb_version=$DOCUMENTDB_VERSION" >> $GITHUB_OUTPUT
     - name: Build Debian Package
       run: |
-        ./packaging/build_packages.sh --os deb13 --pg ${{ matrix.pg_version }} --output-dir downloaded-artifacts
+        DEB_BUILD_OPTIONS=nocheck ./packaging/build_packages.sh --os deb13 --pg ${{ matrix.pg_version }} --output-dir downloaded-artifacts
         ls -R downloaded-artifacts
     - name: Login to GHCR
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -50,6 +50,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
     runs-on: ${{ matrix.runner }}
     outputs:
       documentdb_version: ${{ steps.extract_version.outputs.documentdb_version }}
@@ -146,13 +147,14 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
     runs-on: ubuntu-22.04
     needs: build-and-push
     steps:
     - name: Login to GHCR
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
     - name: Show version
-      run: echo "Using DOCUMENTDB_VERSION=${{ needs.prepare.outputs.documentdb_version }}"
+      run: echo "Using DOCUMENTDB_VERSION=${{ needs.build-and-push.outputs.documentdb_version }}"
     - name: Set Default Values
       run: |
         echo "MANIFEST_TAG=pg${{ matrix.pg_version }}-${{ needs.build-and-push.outputs.documentdb_version }}" >> $GITHUB_ENV
@@ -192,6 +194,7 @@ jobs:
         echo "MANIFEST_TAG=latest" >> $GITHUB_ENV
     - name: Create and Push Manifest
       run: |
+        # Keep the floating latest tag on PG17 for compatibility; PG18 is published via explicit pg18-* tags.
         docker manifest create ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ env.MANIFEST_TAG }} \
           --amend ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-pg17-amd64 \
           --amend ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-pg17-arm64

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -88,6 +88,7 @@ jobs:
         IMAGE=ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:$TAG
         CONTAINER_NAME=documentdb-local-smoke-pg${{ matrix.pg_version }}-${{ matrix.arch }}
         SMOKE_DIR=$(mktemp -d)
+        chmod 755 "$SMOKE_DIR"
         dump_logs=true
         cleanup() {
           if [ "$dump_logs" = "true" ]; then

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -176,6 +176,18 @@ json.dump(data, sys.stdout)
         config = self._read_config()
         self.assertEqual(config["TlsMode"], "requireTLS")
 
+    def test_system_postgres_log_defaults_to_runtime_pg_version(self):
+        result = self._run_entrypoint(
+            "--password",
+            "mypassword",
+            extra_env={"PG_VERSION_USED": "18", "SYSTEM_POSTGRES_LOG": ""},
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "System PostgreSQL logs (/var/log/postgresql/postgresql-18-main.log)",
+            result.stdout,
+        )
+
     def test_invalid_tlsMode_value_fails_fast(self):
         result = self._run_entrypoint(
             "--password",

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -248,7 +248,8 @@ export DISABLE_EXTENDED_RUM=${DISABLE_EXTENDED_RUM:-false}
 export TLS_MODE=${TLS_MODE:-allowTLS}
 export GATEWAY_HOME=${GATEWAY_HOME:-/home/documentdb/gateway}
 export DOCUMENTDB_LOG_DIR=${DOCUMENTDB_LOG_DIR:-/var/log/documentdb}
-export SYSTEM_POSTGRES_LOG=${SYSTEM_POSTGRES_LOG:-/var/log/postgresql/postgresql-17-main.log}
+export POSTGRES_LOG_VERSION=${PG_VERSION_USED:-17}
+export SYSTEM_POSTGRES_LOG=${SYSTEM_POSTGRES_LOG:-/var/log/postgresql/postgresql-${POSTGRES_LOG_VERSION}-main.log}
 export DOCUMENTDB_RUNTIME_USER=${DOCUMENTDB_RUNTIME_USER:-documentdb}
 export DOCUMENTDB_RUNTIME_GROUP=${DOCUMENTDB_RUNTIME_GROUP:-$DOCUMENTDB_RUNTIME_USER}
 
@@ -589,7 +590,7 @@ echo ""
 echo "=== DocumentDB is ready ==="
 echo "All logs are being streamed to docker logs with prefixes:"
 echo "  [POSTGRES] - PostgreSQL database logs ($PG_LOG_FILE)"
-echo "  [POSTGRES-SYSTEM] - System PostgreSQL logs (/var/log/postgresql/postgresql-17-main.log)"
+echo "  [POSTGRES-SYSTEM] - System PostgreSQL logs ($SYSTEM_POSTGRES_LOG)"
 echo "  [OSS-SERVER] - OSS server logs ($OSS_SERVER_LOG)"
 echo "  [ENTRYPOINT] - Entrypoint script logs ($ENTRYPOINT_LOG)"
 echo "  [GATEWAY] - Gateway application logs (live output via tee)"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,7 +16,7 @@ Supported DEB/Ubuntu distributions:
 - ubuntu22.04 — Ubuntu 22.04 (jammy)
 - ubuntu24.04 — Ubuntu 24.04 (noble)
 
-Supported PG versions: 15, 16, 17
+Supported PG versions: 15, 16, 17, 18
 
 ## Building RPM Packages
 
@@ -30,7 +30,7 @@ Supported RPM distributions:
 - rhel8 (Red Hat Enterprise Linux 8 compatible)
 - rhel9 (Red Hat Enterprise Linux 9 compatible)
 
-Supported PG versions: 15, 16, 17
+Supported PG versions: 15, 16, 17, 18
 
 ### RPM Build Prerequisites
 

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -169,7 +169,7 @@ if [[ "$PACKAGE_TYPE" == "deb" ]]; then
         --build-arg POSTGRES_VERSION="$PG" \
         --build-arg DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" "$script_dir"
     # Run the Docker container to build the packages
-    docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" -v "$abs_output_dir:/output" "$TAG"
+    docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" --env DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS:-}" -v "$abs_output_dir:/output" "$TAG"
 elif [[ "$PACKAGE_TYPE" == "rpm" ]]; then
     docker build -t "$TAG" -f "$DOCKERFILE" \
         --build-arg BASE_IMAGE="$DOCKER_IMAGE" \

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -169,7 +169,7 @@ if [[ "$PACKAGE_TYPE" == "deb" ]]; then
         --build-arg POSTGRES_VERSION="$PG" \
         --build-arg DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" "$script_dir"
     # Run the Docker container to build the packages
-    docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" --env DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS:-}" -v "$abs_output_dir:/output" "$TAG"
+    docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" -v "$abs_output_dir:/output" "$TAG"
 elif [[ "$PACKAGE_TYPE" == "rpm" ]]; then
     docker build -t "$TAG" -f "$DOCKERFILE" \
         --build-arg BASE_IMAGE="$DOCKER_IMAGE" \

--- a/packaging/deb/common/rules
+++ b/packaging/deb/common/rules
@@ -4,7 +4,9 @@
 	dh $@
 
 override_dh_auto_test:
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	make install
 	adduser --disabled-password --gecos "" documentdb
 	chown -R documentdb:documentdb .
 	su documentdb -c "make check"
+endif

--- a/packaging/deb/common/rules
+++ b/packaging/deb/common/rules
@@ -4,9 +4,7 @@
 	dh $@
 
 override_dh_auto_test:
-ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	make install
 	adduser --disabled-password --gecos "" documentdb
 	chown -R documentdb:documentdb .
 	su documentdb -c "make check"
-endif

--- a/packaging/gateway/build_gateway_packages.sh
+++ b/packaging/gateway/build_gateway_packages.sh
@@ -14,7 +14,7 @@ function show_help {
     echo ""
     echo "Mandatory Arguments:"
     echo "  --os                 OS to build packages for. Possible values: [deb11, deb12, deb13, ubuntu22.04, ubuntu24.04, rhel8, rhel9]"
-    echo "  --pg                 PG version to build packages for. Possible values: [15, 16, 17]"
+    echo "  --pg                 PG version to build packages for. Possible values: [15, 16, 17, 18]"
     echo ""
     echo "Optional Arguments:"
     echo "  --version            The version of documentdb to build. Examples: [0.100.0, 0.101.0]"
@@ -172,6 +172,7 @@ if [[ $TEST_CLEAN_INSTALL == true ]]; then
         # Build the Docker image while showing the output to the console
         docker build -t documentdb-test-gateway-packages:latest -f "${script_dir}/packaging/gateway/test/Dockerfile_deb_gateway_test" \
             --build-arg BASE_IMAGE="$TEST_DOCKER_IMAGE" \
+            --build-arg POSTGRES_VERSION="$PG" \
             --build-arg DEB_PACKAGE_REL_PATH="$deb_package_rel_path" \
             --build-arg GATEWAY_PACKAGE_PATH="$gateway_package_rel_path" "$script_dir"
         # Run the Docker container to test the packages

--- a/packaging/gateway/test/Dockerfile_deb_gateway_test
+++ b/packaging/gateway/test/Dockerfile_deb_gateway_test
@@ -31,12 +31,16 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" \
         > /etc/apt/sources.list.d/pgdg.list; \
     apt-get update; \
+    RUM_PKG=""; \
+    if [ "${POSTGRES_VERSION}" -lt 18 ]; then \
+        RUM_PKG="postgresql-${POSTGRES_VERSION}-rum"; \
+    fi; \
     apt-get install -y --no-install-recommends \
         postgresql-${POSTGRES_VERSION} \
         postgresql-${POSTGRES_VERSION}-cron \
         postgresql-${POSTGRES_VERSION}-pgvector \
         postgresql-${POSTGRES_VERSION}-postgis-3 \
-        postgresql-${POSTGRES_VERSION}-rum \
+        $RUM_PKG \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- add PostgreSQL 18 to the documentdb-local image and manifest workflow matrices
- keep the floating `latest` image on PG17 for compatibility while publishing explicit PG18 tags
- make runtime log paths and gateway package validation respect the selected PostgreSQL version
- keep Debian package tests enabled for documentdb-local image package builds
- fix smoke-test init data mount permissions so the container runtime user can read custom init scripts

## Validation
- parsed `.github/workflows/build_gateway.yml`
- `bash -n packaging/build_packages.sh documentdb-local/scripts/emulator_entrypoint.sh packaging/gateway/build_gateway_packages.sh`
- `python3 -m unittest discover -s documentdb-local/scripts/documentdb_local_tests -p 'test_emulator_entrypoint.py'`
- `git diff --check`

## Notes
A previous workflow run confirmed the generated PG18 amd64/arm64 containers can build, publish, and smoke-test when image generation is allowed to reach the Docker steps. With package tests restored, the image workflow will continue to run the Debian package regression suite before building the image.
