### PR TITLE
Add comprehensive integration tests and CI workflow for documentdb-local

### DIFF
--- a/.github/workflows/documentdb_local_image_tests.yml
+++ b/.github/workflows/documentdb_local_image_tests.yml
@@ -1,0 +1,373 @@
+name: DocumentDB local image tests
+run-name: ${{ github.event.pull_request.title || '' }}
+concurrency:
+  group: documentdb-local-image-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths-ignore:
+      - '.devcontainer/**'
+      - '**/*.md'
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '**/*.md'
+
+env:
+  IMAGE_REF: documentdb-local:image-tests
+  DOCUMENTDB_USER: docdb_admin
+  DOCUMENTDB_PORT: '10260'
+
+# Matrix policy:
+#   - PG 17 and PG 18 only. PG17 is what `documentdb-local:latest` ships as,
+#     so it matches the image most users pull. PG18 is the divergent case
+#     (no upstream `rum`, must use `documentdb_extended_rum`).
+#   - amd64 and arm64. The image is published to both architectures; the
+#     test surface should fail loudly if either arch breaks.
+#   - PG 15 / 16 add no unique signal that PG 17 does not already cover at
+#     this layer; gateway_tests.yml and regress_tests.yml exercise them at
+#     the extension/SQL layer where the differences actually live.
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # build-image: 2 PG x 2 arch = 4 jobs. Each one builds the deb, builds the
+  # documentdb-local image natively on the matching arch runner, and uploads
+  # the saved image as a workflow artifact for the downstream test jobs.
+  # ---------------------------------------------------------------------------
+  build-image:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: Build PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build Debian package
+        run: |
+          ./packaging/build_packages.sh \
+            --os deb13 \
+            --pg ${{ matrix.pg_version }} \
+            --output-dir downloaded-artifacts
+          ls -la downloaded-artifacts/
+
+      - name: Build documentdb-local image
+        run: |
+          set -euo pipefail
+          DEB_FILE=$(find downloaded-artifacts -maxdepth 1 -type f -name '*.deb' \
+                       ! -name '*dbgsym*' | sort | head -1)
+          if [ -z "$DEB_FILE" ]; then
+            echo "No non-dbgsym .deb package found in downloaded-artifacts/" >&2
+            ls -la downloaded-artifacts/ >&2
+            exit 1
+          fi
+          echo "Building ${IMAGE_REF} from ${DEB_FILE} for linux/${{ matrix.arch }}"
+          docker build \
+            --platform linux/${{ matrix.arch }} \
+            --build-arg BASE_IMAGE=debian:trixie-slim \
+            --build-arg POSTGRES_VERSION=${{ matrix.pg_version }} \
+            --build-arg "DEB_PACKAGE_REL_PATH=${DEB_FILE}" \
+            -t "$IMAGE_REF" \
+            -f packaging/gateway/docker/Dockerfile_documentdb_local .
+          docker image inspect "$IMAGE_REF" \
+            --format 'Built {{.RepoTags}} ({{.Architecture}}, size={{.Size}} bytes)'
+
+      - name: Save image as artifact
+        run: |
+          mkdir -p /tmp/image
+          docker save "$IMAGE_REF" \
+            | gzip > "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+          ls -lh /tmp/image/
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # data-plane-tests: every tests/*.js file under integration-tests/ executed
+  # against a single short-lived container per (PG, arch) via run.sh. Covers
+  # connectivity, CRUD, query/update operators, indexes, aggregation,
+  # collection management, BSON types, cursors/projection, and error handling.
+  # ---------------------------------------------------------------------------
+  data-plane-tests:
+    needs: build-image
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: Data-plane PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download documentdb-local image
+        uses: actions/download-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image
+
+      - name: Load documentdb-local image
+        run: |
+          docker load < "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+          docker image inspect "$IMAGE_REF" --format '{{.RepoTags}} ({{.Architecture}})'
+
+      - name: Run data-plane integration tests
+        run: |
+          mkdir -p .test-results/data-plane
+          ./documentdb-local/integration-tests/run.sh \
+            --image "$IMAGE_REF" \
+            --user "$DOCUMENTDB_USER" \
+            --port "$DOCUMENTDB_PORT" \
+            --results-dir ".test-results/data-plane"
+
+      - name: Upload data-plane logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tests-logs-data-plane-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          overwrite: true
+          path: .test-results/data-plane/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # auth-tests: correct creds, wrong password, wrong user, unauthenticated,
+  # --create-user false clean start.
+  # ---------------------------------------------------------------------------
+  auth-tests:
+    needs: build-image
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: Auth PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download documentdb-local image
+        uses: actions/download-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image
+
+      - name: Load documentdb-local image
+        run: docker load < "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+
+      - name: Run auth scenarios
+        run: |
+          mkdir -p .test-results/auth
+          ./documentdb-local/integration-tests/scenarios/auth.sh \
+            "$IMAGE_REF" \
+            .test-results/auth
+
+      - name: Upload auth logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tests-logs-auth-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          overwrite: true
+          path: .test-results/auth/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # tls-tests: reuses the existing run_documentdb_local_tls_tests.sh which
+  # exercises default allowTLS, --tlsMode requireTLS, and TLS_MODE env var,
+  # plus rejection of an invalid TLS_MODE value.
+  # ---------------------------------------------------------------------------
+  tls-tests:
+    needs: build-image
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: TLS PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download documentdb-local image
+        uses: actions/download-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image
+
+      - name: Load documentdb-local image
+        run: docker load < "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+
+      - name: Run TLS-mode tests
+        run: |
+          mkdir -p .test-results/tls
+          ./documentdb-local/scripts/run_documentdb_local_tls_tests.sh \
+            "$IMAGE_REF" \
+            .test-results/tls
+
+      - name: Upload TLS logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tests-logs-tls-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          overwrite: true
+          path: .test-results/tls/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # init-data-tests: --init-data true (built-in sampledb), custom volume-
+  # mounted scripts, --skip-init-data, and rejection of invalid JS.
+  # ---------------------------------------------------------------------------
+  init-data-tests:
+    needs: build-image
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: Init-data PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download documentdb-local image
+        uses: actions/download-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image
+
+      - name: Load documentdb-local image
+        run: docker load < "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+
+      - name: Run init-data scenarios
+        run: |
+          mkdir -p .test-results/init-data
+          ./documentdb-local/integration-tests/scenarios/init-data.sh \
+            "$IMAGE_REF" \
+            .test-results/init-data
+
+      - name: Upload init-data logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tests-logs-init-data-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          overwrite: true
+          path: .test-results/init-data/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # persistence-tests: write data + custom index in container A on shared
+  # /data volume, restart in container B, verify content + index survived
+  # and post-restart writes succeed.
+  # ---------------------------------------------------------------------------
+  persistence-tests:
+    needs: build-image
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    name: Persistence PG${{ matrix.pg_version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download documentdb-local image
+        uses: actions/download-artifact@v4
+        with:
+          name: documentdb-local-image-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          path: /tmp/image
+
+      - name: Load documentdb-local image
+        run: docker load < "/tmp/image/documentdb-local-pg${{ matrix.pg_version }}-${{ matrix.arch }}.tar.gz"
+
+      - name: Run persistence scenario
+        run: |
+          mkdir -p .test-results/persistence
+          ./documentdb-local/integration-tests/scenarios/persistence.sh \
+            "$IMAGE_REF" \
+            .test-results/persistence
+
+      - name: Upload persistence logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tests-logs-persistence-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+          overwrite: true
+          path: .test-results/persistence/
+          retention-days: 7

--- a/documentdb-local/integration-tests/README.md
+++ b/documentdb-local/integration-tests/README.md
@@ -1,0 +1,123 @@
+# DocumentDB local image integration tests
+
+End-to-end tests that exercise a running `documentdb-local` container against
+the wire-protocol API surface that the image promises. They complement two
+neighboring suites:
+
+| Suite | Lives in | Tests |
+| --- | --- | --- |
+| Entrypoint unit tests | `scripts/documentdb_local_tests/` | The `emulator_entrypoint.sh` shell logic in isolation |
+| Upstream compatibility gate | `functional-tests/` | A pinned upstream pytest image against the running container |
+| **Integration tests (this folder)** | `integration-tests/` | Image-level concerns: data-plane via mongosh, container config scenarios |
+
+The integration tests are owned by `documentdb-local`. They give PR-time
+feedback even when only image-level files change (entrypoint, init-data
+scripts, Dockerfile, gateway packaging) and they keep the contract narrow
+enough to remain green across PG 15 / 16 / 17 / 18.
+
+## Layout
+
+```text
+integration-tests/
+  README.md
+  run.sh                   Local runner that orchestrates data-plane tests
+  tests/                   mongosh JS files run via `mongosh --file`
+    00-connectivity.js     ping / hello / buildInfo / listDatabases / serverStatus / dbStats / collStats
+    01-crud.js             insert / find / count / distinct / update / delete + query operators
+    02-update-operators.js field and array update operators, positional, upsert + $setOnInsert
+    03-indexes.js          single / compound / unique / sparse / partial / TTL / multikey
+    04-aggregation.js      stages, expressions, accumulators across the supported surface
+    05-collection-and-database.js  createCollection / validators / views / rename / dropDatabase
+    06-bson-types.js       every BSON type the gateway exposes through mongosh
+    07-cursors-and-projection.js   projection forms, batchSize / getMore, sort+skip+limit
+    08-error-handling.js   duplicate-key, validator rejection, invalid update operator, unknown command
+  scenarios/               Bash scripts that each start their own container with a
+                           specific configuration and verify behavior
+    auth.sh                correct creds, wrong password, wrong user, missing creds, --create-user false
+    init-data.sh           --init-data true, custom volume mount, --skip-init-data, invalid JS rejected
+    persistence.sh         mount /data volume, write docs, restart container, verify data survives
+```
+
+TLS-mode behavior is covered by the existing
+[`scripts/run_documentdb_local_tls_tests.sh`](../scripts/run_documentdb_local_tls_tests.sh)
+and is wired into the same CI workflow.
+
+## Test conventions
+
+Each `tests/*.js` file is **self-contained**:
+
+- Drops its own database (`it_<NN>_<name>`) at the start for idempotency.
+- Defines small inline `assert` / `assertEq` / `check(name, fn)` helpers.
+- Calls `quit(1)` if any check failed, so `mongosh --file` exits non-zero and
+  the runner propagates failure.
+- Prints `PASS` / `FAIL` per check and a summary line, so logs are easy to
+  scan.
+
+The runner mounts the `tests/` directory into the container read-only and
+invokes each file in alphabetical order with `docker exec ... mongosh --file`.
+A single container is reused across every JS test file in one run, which keeps
+the data-plane suite fast.
+
+## Run locally
+
+Build the image and run all data-plane tests:
+
+```bash
+# from the repo root
+./packaging/build_packages.sh --os deb13 --pg 17 --output-dir downloaded-artifacts
+DEB_FILE=$(find downloaded-artifacts -maxdepth 1 -type f -name '*.deb' ! -name '*dbgsym*' | sort | head -1)
+docker build \
+  --build-arg BASE_IMAGE=debian:trixie-slim \
+  --build-arg POSTGRES_VERSION=17 \
+  --build-arg "DEB_PACKAGE_REL_PATH=${DEB_FILE}" \
+  -t documentdb-local:dev \
+  -f packaging/gateway/docker/Dockerfile_documentdb_local .
+
+./documentdb-local/integration-tests/run.sh --image documentdb-local:dev
+```
+
+Run a single test file against an already-running container managed by the
+runner:
+
+```bash
+./documentdb-local/integration-tests/run.sh \
+  --image documentdb-local:dev \
+  --only 03-indexes.js
+```
+
+Run the scenario scripts (each manages its own container):
+
+```bash
+./documentdb-local/integration-tests/scenarios/auth.sh        documentdb-local:dev
+./documentdb-local/integration-tests/scenarios/init-data.sh   documentdb-local:dev
+./documentdb-local/integration-tests/scenarios/persistence.sh documentdb-local:dev
+```
+
+## CI
+
+`.github/workflows/documentdb_local_image_tests.yml` runs everything on every
+non-draft pull request, every push to `main`, and on `workflow_dispatch`.
+Layout:
+
+1. `build-image` (matrix per PG) - builds the deb, builds the image,
+   uploads it as an artifact named `documentdb-local-image-pg<N>`.
+2. `data-plane-tests` (matrix per PG) - downloads the artifact and runs
+   every `tests/*.js` via `run.sh`.
+3. `auth-tests`, `tls-tests`, `init-data-tests`, `persistence-tests`
+   (matrix per PG) - download the artifact and run the matching scenario
+   script.
+
+Each test job uploads per-PG logs and the container `docker logs` output on
+failure under `image-tests-logs-<job>-pg<N>`.
+
+## Adding a new test
+
+- For a data-plane operator or command, add a `check(...)` to the most
+  relevant `tests/*.js` file. Keep checks focused (one assertion per check
+  is ideal, multiple are fine if they describe one behavior).
+- For a new container-configuration scenario (a new entrypoint flag, a
+  new env var), add a `scenarios/<name>.sh` script and wire it into the
+  workflow with its own matrix job.
+- Avoid features that the upstream `functional-tests` allowlist does not
+  already cover (text search, 2dsphere, transactions): they would create
+  PR-time flakes without adding stable value.

--- a/documentdb-local/integration-tests/run.sh
+++ b/documentdb-local/integration-tests/run.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Local runner for the documentdb-local integration tests.
+#
+# Builds nothing - takes an image reference, starts a fresh container with
+# --skip-init-data, mounts the tests/ directory read-only, then executes
+# every tests/*.js file with `docker exec mongosh --file`. Prints PASS/FAIL
+# per file and a summary at the end. Exits non-zero if any test file fails.
+#
+# Usage:
+#   ./integration-tests/run.sh --image documentdb-local:dev
+#   ./integration-tests/run.sh --image documentdb-local:dev --only 03-indexes.js
+#   ./integration-tests/run.sh --image documentdb-local:dev --results-dir /tmp/results
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTS_DIR="${SCRIPT_DIR}/tests"
+
+IMAGE_REF=""
+CONTAINER_NAME="documentdb-local-integration-$$"
+DOCUMENTDB_USER="docdb_admin"
+DOCUMENTDB_PASSWORD=""
+DOCUMENTDB_PORT="10260"
+ONLY=""
+RESULTS_DIR=""
+READY_TIMEOUT="240"
+KEEP_CONTAINER="false"
+
+usage() {
+    cat <<EOF
+Run the documentdb-local integration tests against a built image.
+
+Options:
+  --image <ref>            Docker image reference (required).
+  --container <name>       Container name (default: documentdb-local-integration-<pid>).
+  --user <name>            DocumentDB username (default: docdb_admin).
+  --password <pw>          DocumentDB password (default: a random 32-char string).
+  --port <port>            Container port for the gateway (default: 10260).
+  --only <file>            Run a single tests/<file> only (basename, e.g. 03-indexes.js).
+  --results-dir <path>     Write container logs to this directory on failure.
+  --ready-timeout <secs>   Time to wait for the readiness log line (default: 240).
+  --keep-container         Leave the container running after the run.
+  -h, --help               Show this help.
+
+Examples:
+  $0 --image documentdb-local:dev
+  $0 --image documentdb-local:dev --only 03-indexes.js
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)           IMAGE_REF="$2"; shift 2 ;;
+        --container)       CONTAINER_NAME="$2"; shift 2 ;;
+        --user)            DOCUMENTDB_USER="$2"; shift 2 ;;
+        --password)        DOCUMENTDB_PASSWORD="$2"; shift 2 ;;
+        --port)            DOCUMENTDB_PORT="$2"; shift 2 ;;
+        --only)            ONLY="$2"; shift 2 ;;
+        --results-dir)     RESULTS_DIR="$2"; shift 2 ;;
+        --ready-timeout)   READY_TIMEOUT="$2"; shift 2 ;;
+        --keep-container)  KEEP_CONTAINER="true"; shift ;;
+        -h|--help)         usage; exit 0 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$IMAGE_REF" ]; then
+    echo "Error: --image is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [ ! -d "$TESTS_DIR" ]; then
+    echo "Error: tests directory not found: $TESTS_DIR" >&2
+    exit 1
+fi
+
+if [ -z "$DOCUMENTDB_PASSWORD" ]; then
+    DOCUMENTDB_PASSWORD=$(python3 -c \
+      'import secrets, string; print("".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))')
+fi
+
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
+cleanup() {
+    local code=$?
+    if [ "$KEEP_CONTAINER" = "true" ]; then
+        echo "Leaving container running: $CONTAINER_NAME"
+    else
+        if [ -n "$RESULTS_DIR" ] && [ "$code" -ne 0 ]; then
+            mkdir -p "$RESULTS_DIR"
+            docker logs "$CONTAINER_NAME" \
+                > "$RESULTS_DIR/$(basename "$CONTAINER_NAME").log" 2>&1 || true
+        fi
+        docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+    exit "$code"
+}
+trap cleanup EXIT
+
+wait_for_log() {
+    local pattern="$1"
+    local timeout_seconds="$2"
+    local waited=0
+    while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -Fq "$pattern"; do
+        local running
+        running=$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" \
+            2>/dev/null || echo false)
+        if [ "$running" != "true" ]; then
+            echo "Container exited before log pattern appeared: $pattern" >&2
+            docker logs "$CONTAINER_NAME" || true
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$timeout_seconds" ]; then
+            echo "Timed out waiting for log pattern: $pattern" >&2
+            docker logs "$CONTAINER_NAME" || true
+            return 1
+        fi
+    done
+}
+
+echo "Starting container ${CONTAINER_NAME} from image ${IMAGE_REF}..."
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    --mount "type=bind,source=${TESTS_DIR},target=/integration-tests,readonly" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --skip-init-data >/dev/null
+
+wait_for_log "=== DocumentDB is ready ===" "$READY_TIMEOUT"
+echo "Container is ready."
+
+# Build the test-file list. Prefer find . -maxdepth 1 over ls | grep so the
+# order is alphabetical and non-script files do not sneak in.
+mapfile -t test_files < <(
+    cd "$TESTS_DIR" && \
+        find . -maxdepth 1 -type f -name '*.js' -printf '%f\n' | sort
+)
+
+if [ -n "$ONLY" ]; then
+    test_files=("$ONLY")
+    if [ ! -f "${TESTS_DIR}/${ONLY}" ]; then
+        echo "Error: --only file does not exist: ${TESTS_DIR}/${ONLY}" >&2
+        exit 1
+    fi
+fi
+
+if [ "${#test_files[@]}" -eq 0 ]; then
+    echo "Error: no test files found in ${TESTS_DIR}" >&2
+    exit 1
+fi
+
+passed_files=()
+failed_files=()
+
+for tf in "${test_files[@]}"; do
+    echo ""
+    echo "------------------------------------------------------------"
+    echo "Running ${tf}"
+    echo "------------------------------------------------------------"
+
+    if docker exec -i "$CONTAINER_NAME" mongosh \
+        "localhost:${DOCUMENTDB_PORT}" \
+        -u "$DOCUMENTDB_USER" -p "$DOCUMENTDB_PASSWORD" \
+        --authenticationMechanism SCRAM-SHA-256 \
+        --tls --tlsAllowInvalidCertificates \
+        --quiet \
+        --file "/integration-tests/${tf}"; then
+        passed_files+=("$tf")
+    else
+        failed_files+=("$tf")
+    fi
+done
+
+echo ""
+echo "============================================================"
+echo "Integration test summary"
+echo "============================================================"
+echo "Passed (${#passed_files[@]}):"
+for f in "${passed_files[@]}"; do echo "  PASS  $f"; done
+echo "Failed (${#failed_files[@]}):"
+for f in "${failed_files[@]}"; do echo "  FAIL  $f"; done
+
+if [ "${#failed_files[@]}" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/documentdb-local/integration-tests/scenarios/auth.sh
+++ b/documentdb-local/integration-tests/scenarios/auth.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#
+# Scenario: authentication.
+#
+# Exercises the auth surface of documentdb-local:
+#   - correct creds succeed
+#   - wrong password is rejected
+#   - wrong username is rejected
+#   - missing creds are rejected
+#   - --create-user false skips user creation, default seeded admin still works
+#
+# Usage:
+#   ./scenarios/auth.sh <image_ref> [results_dir]
+
+set -euo pipefail
+
+IMAGE_REF="${1:?image reference required as the first argument}"
+RESULTS_DIR="${2:-.test-results/integration-auth}"
+
+mkdir -p "$RESULTS_DIR"
+
+SUFFIX="$$"
+USER_CONTAINER="docdb-auth-user-${SUFFIX}"
+NOUSER_CONTAINER="docdb-auth-nouser-${SUFFIX}"
+
+DOCUMENTDB_USER="docdb_admin"
+DOCUMENTDB_PASSWORD="$(python3 -c \
+    'import secrets, string; print("".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))')"
+# A deliberately different password used for the negative-test container.
+WRONG_PASSWORD="${DOCUMENTDB_PASSWORD}-wrong"
+
+cleanup() {
+    for container in "$USER_CONTAINER" "$NOUSER_CONTAINER"; do
+        if docker ps -a --format '{{.Names}}' | grep -Fxq "$container"; then
+            docker logs "$container" \
+                > "${RESULTS_DIR}/${container}.log" 2>&1 || true
+            docker rm -f "$container" >/dev/null 2>&1 || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+wait_for_ready() {
+    local container="$1"
+    local waited=0
+    local timeout=240
+    while ! docker logs "$container" 2>&1 | grep -Fq "=== DocumentDB is ready ==="; do
+        local running
+        running=$(docker inspect -f '{{.State.Running}}' "$container" \
+            2>/dev/null || echo false)
+        if [ "$running" != "true" ]; then
+            echo "Container ${container} exited before becoming ready." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$timeout" ]; then
+            echo "Timed out waiting for ${container} readiness." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+    done
+}
+
+mongosh_eval() {
+    # Args: container, username, password, eval-string
+    local container="$1"; shift
+    local user="$1"; shift
+    local pw="$1"; shift
+    local code="$1"; shift
+    docker exec -i "$container" mongosh \
+        "localhost:10260" \
+        -u "$user" -p "$pw" \
+        --authenticationMechanism SCRAM-SHA-256 \
+        --tls --tlsAllowInvalidCertificates \
+        --quiet \
+        --eval "$code"
+}
+
+mongosh_unauth_eval() {
+    local container="$1"; shift
+    local code="$1"; shift
+    docker exec -i "$container" mongosh \
+        "localhost:10260" \
+        --tls --tlsAllowInvalidCertificates \
+        --quiet \
+        --eval "$code"
+}
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1: $2" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Scenario 1: --username / --password creates a usable account
+# ---------------------------------------------------------------------------
+
+echo "=== Scenario: --username + --password creates a working account ==="
+
+docker run -d \
+    --name "$USER_CONTAINER" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --skip-init-data >/dev/null
+wait_for_ready "$USER_CONTAINER"
+
+# Positive: correct creds get ok=1 on ping.
+out=$(mongosh_eval "$USER_CONTAINER" "$DOCUMENTDB_USER" "$DOCUMENTDB_PASSWORD" \
+    'db.runCommand({ping: 1}).ok')
+last=$(printf '%s' "$out" | tr -d '\r' | tail -n1)
+if [ "$last" = "1" ]; then
+    pass "correct creds succeed"
+else
+    fail "correct creds succeed" "ping last line was '$last' (full: $out)"
+fi
+
+# Negative: wrong password is rejected.
+if mongosh_eval "$USER_CONTAINER" "$DOCUMENTDB_USER" "$WRONG_PASSWORD" \
+    'db.runCommand({ping: 1})' >/dev/null 2>&1; then
+    fail "wrong password rejected" "ping unexpectedly succeeded with wrong password"
+fi
+pass "wrong password rejected"
+
+# Negative: wrong username is rejected.
+if mongosh_eval "$USER_CONTAINER" "no_such_user" "$DOCUMENTDB_PASSWORD" \
+    'db.runCommand({ping: 1})' >/dev/null 2>&1; then
+    fail "wrong username rejected" "ping unexpectedly succeeded with unknown user"
+fi
+pass "wrong username rejected"
+
+# Negative: unauthenticated connection is rejected. We probe with
+# `listDatabases` rather than `ping` because the MongoDB wire protocol
+# allows ping (and a handful of other handshake commands) to succeed
+# without authentication by design; the documentdb gateway follows that
+# rule, so a `ping`-based check is a false negative.
+if mongosh_unauth_eval "$USER_CONTAINER" \
+    'db.adminCommand({listDatabases: 1})' >/dev/null 2>&1; then
+    fail "unauthenticated rejected" "listDatabases unexpectedly succeeded without creds"
+fi
+pass "unauthenticated rejected"
+
+docker rm -f "$USER_CONTAINER" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Scenario 2: --create-user false starts cleanly. We intentionally do not
+# assert on which credentials work here, because that depends on whether
+# any account was provisioned at PG initdb time, which is outside the
+# documentdb-local image's contract. The check that matters is that the
+# entrypoint takes the no-user code path, reaches readiness, and stays up.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Scenario: --create-user false starts cleanly ==="
+
+docker run -d \
+    --name "$NOUSER_CONTAINER" \
+    "$IMAGE_REF" \
+    --create-user false \
+    --skip-init-data >/dev/null
+wait_for_ready "$NOUSER_CONTAINER"
+pass "container with --create-user false reaches readiness"
+
+# The container should still be running a few seconds after readiness; this
+# guards against the entrypoint racing on a missing user and exiting.
+sleep 3
+running=$(docker inspect -f '{{.State.Running}}' "$NOUSER_CONTAINER" \
+    2>/dev/null || echo false)
+if [ "$running" != "true" ]; then
+    fail "container with --create-user false stays running" \
+        "container is no longer running after readiness"
+fi
+pass "container with --create-user false stays running after readiness"
+
+docker rm -f "$NOUSER_CONTAINER" >/dev/null
+
+echo ""
+echo "All auth scenarios passed."

--- a/documentdb-local/integration-tests/scenarios/init-data.sh
+++ b/documentdb-local/integration-tests/scenarios/init-data.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+#
+# Scenario: init-data.
+#
+# Exercises the four init-data code paths in scripts/init_documentdb_data.sh:
+#   1. --init-data true loads the built-in sample-data into 'sampledb'
+#   2. --init-data-path /path with user-mounted *.js loads custom data
+#   3. --skip-init-data leaves the server bare (no sampledb)
+#   4. Invalid JS in the init-data directory causes the container to exit
+#      with non-zero, instead of silently coming up with partial state.
+#
+# Usage:
+#   ./scenarios/init-data.sh <image_ref> [results_dir]
+
+set -euo pipefail
+
+IMAGE_REF="${1:?image reference required as the first argument}"
+RESULTS_DIR="${2:-.test-results/integration-init-data}"
+
+mkdir -p "$RESULTS_DIR"
+
+SUFFIX="$$"
+BUILTIN_CONTAINER="docdb-init-builtin-${SUFFIX}"
+CUSTOM_CONTAINER="docdb-init-custom-${SUFFIX}"
+SKIP_CONTAINER="docdb-init-skip-${SUFFIX}"
+INVALID_CONTAINER="docdb-init-invalid-${SUFFIX}"
+
+DOCUMENTDB_USER="docdb_admin"
+DOCUMENTDB_PASSWORD="$(python3 -c \
+    'import secrets, string; print("".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))')"
+
+CUSTOM_DIR="$(mktemp -d -t docdb-init-custom.XXXXXX)"
+INVALID_DIR="$(mktemp -d -t docdb-init-invalid.XXXXXX)"
+
+cleanup() {
+    for container in "$BUILTIN_CONTAINER" "$CUSTOM_CONTAINER" \
+                     "$SKIP_CONTAINER" "$INVALID_CONTAINER"; do
+        if docker ps -a --format '{{.Names}}' | grep -Fxq "$container"; then
+            docker logs "$container" \
+                > "${RESULTS_DIR}/${container}.log" 2>&1 || true
+            docker rm -f "$container" >/dev/null 2>&1 || true
+        fi
+    done
+    rm -rf "$CUSTOM_DIR" "$INVALID_DIR"
+}
+trap cleanup EXIT
+
+wait_for_ready() {
+    local container="$1"
+    local waited=0
+    local timeout="${2:-240}"
+    while ! docker logs "$container" 2>&1 | grep -Fq "=== DocumentDB is ready ==="; do
+        local running
+        running=$(docker inspect -f '{{.State.Running}}' "$container" \
+            2>/dev/null || echo false)
+        if [ "$running" != "true" ]; then
+            echo "Container ${container} exited before becoming ready." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$timeout" ]; then
+            echo "Timed out waiting for ${container} readiness." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+    done
+}
+
+wait_for_log() {
+    local container="$1"
+    local pattern="$2"
+    local timeout="${3:-240}"
+    local waited=0
+    while ! docker logs "$container" 2>&1 | grep -Fq "$pattern"; do
+        local running
+        running=$(docker inspect -f '{{.State.Running}}' "$container" \
+            2>/dev/null || echo true)
+        if [ "$running" != "true" ]; then
+            echo "Container ${container} exited before pattern '${pattern}'." >&2
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$timeout" ]; then
+            echo "Timed out waiting for '${pattern}' in ${container}." >&2
+            return 1
+        fi
+    done
+}
+
+mongosh_eval() {
+    local container="$1"; shift
+    local code="$1"; shift
+    docker exec -i "$container" mongosh \
+        "localhost:10260" \
+        -u "$DOCUMENTDB_USER" -p "$DOCUMENTDB_PASSWORD" \
+        --authenticationMechanism SCRAM-SHA-256 \
+        --tls --tlsAllowInvalidCertificates \
+        --quiet \
+        --eval "$code"
+}
+
+assert_count_eq() {
+    local container="$1"
+    local db_name="$2"
+    local coll_name="$3"
+    local expected="$4"
+    local label="$5"
+
+    local raw
+    raw=$(mongosh_eval "$container" \
+        "db.getSiblingDB('${db_name}').getCollection('${coll_name}').countDocuments()")
+    local got
+    got=$(printf '%s' "$raw" | tr -d '\r' | tail -n1)
+    if [ "$got" = "$expected" ]; then
+        echo "  PASS  ${label} (expected ${expected}, got ${got})"
+    else
+        echo "  FAIL  ${label}: expected ${expected}, got '${got}' (raw: ${raw})" >&2
+        exit 1
+    fi
+}
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1: $2" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Scenario 1: --init-data true populates the built-in sampledb
+# ---------------------------------------------------------------------------
+
+echo "=== Scenario: --init-data true loads built-in sample data ==="
+
+docker run -d \
+    --name "$BUILTIN_CONTAINER" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --init-data true >/dev/null
+wait_for_ready "$BUILTIN_CONTAINER"
+wait_for_log "$BUILTIN_CONTAINER" "Sample data initialization completed!" 240
+
+assert_count_eq "$BUILTIN_CONTAINER" sampledb users    5 "sampledb.users == 5"
+assert_count_eq "$BUILTIN_CONTAINER" sampledb products 5 "sampledb.products == 5"
+assert_count_eq "$BUILTIN_CONTAINER" sampledb orders   4 "sampledb.orders == 4"
+
+docker rm -f "$BUILTIN_CONTAINER" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Scenario 2: custom --init-data-path via volume mount
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Scenario: custom init-data via volume mount ==="
+
+cat > "$CUSTOM_DIR/01-seed.js" <<'JS'
+use('customdb');
+db.widgets.insertMany([
+  { _id: 1, color: 'red',   qty: 3 },
+  { _id: 2, color: 'green', qty: 5 },
+  { _id: 3, color: 'blue',  qty: 7 },
+]);
+db.widgets.createIndex({ color: 1 }, { name: 'color_1' });
+JS
+
+cat > "$CUSTOM_DIR/02-more.js" <<'JS'
+use('customdb');
+db.tags.insertOne({ _id: 1, name: 'alpha' });
+JS
+
+docker run -d \
+    --name "$CUSTOM_CONTAINER" \
+    --mount "type=bind,source=${CUSTOM_DIR},target=/init_doc_db.d,readonly" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --init-data-path /init_doc_db.d >/dev/null
+wait_for_ready "$CUSTOM_CONTAINER"
+wait_for_log "$CUSTOM_CONTAINER" "Sample data initialization completed!" 240
+
+assert_count_eq "$CUSTOM_CONTAINER" customdb widgets 3 "customdb.widgets == 3"
+assert_count_eq "$CUSTOM_CONTAINER" customdb tags    1 "customdb.tags == 1"
+
+# Verify the index from the init script materialized.
+raw=$(mongosh_eval "$CUSTOM_CONTAINER" \
+    "JSON.stringify(db.getSiblingDB('customdb').widgets.getIndexes().map(i => i.name))")
+if echo "$raw" | grep -Fq "color_1"; then
+    pass "color_1 index created by init script"
+else
+    fail "color_1 index created by init script" "indexes: $raw"
+fi
+
+docker rm -f "$CUSTOM_CONTAINER" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Scenario 3: --skip-init-data leaves the server bare
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Scenario: --skip-init-data leaves the server bare ==="
+
+docker run -d \
+    --name "$SKIP_CONTAINER" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --skip-init-data >/dev/null
+wait_for_ready "$SKIP_CONTAINER"
+
+# sampledb should not exist.
+raw=$(mongosh_eval "$SKIP_CONTAINER" \
+    "JSON.stringify(db.adminCommand({listDatabases: 1, nameOnly: true}).databases.map(x => x.name))")
+if echo "$raw" | grep -Fq "sampledb"; then
+    fail "no sampledb after --skip-init-data" "databases: $raw"
+fi
+pass "no sampledb after --skip-init-data"
+
+# Make sure the database is healthy enough to write/read after skip.
+out=$(mongosh_eval "$SKIP_CONTAINER" 'db.runCommand({ping: 1}).ok')
+last=$(printf '%s' "$out" | tr -d '\r' | tail -n1)
+[ "$last" = "1" ] || fail "ping after --skip-init-data" "ping last line: $last"
+pass "ping after --skip-init-data"
+
+docker rm -f "$SKIP_CONTAINER" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Scenario 4: invalid JS init-data causes the container to exit non-zero
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Scenario: invalid init JS makes the container exit non-zero ==="
+
+cat > "$INVALID_DIR/01-bad.js" <<'JS'
+// Deliberately broken: missing closing quote and bracket.
+use('bad');
+db.broken.insertOne({ k: "unterminated string
+JS
+
+# Run the container in the foreground so we can directly observe its exit
+# code. --init-data-path with broken JS should make init_documentdb_data.sh
+# return non-zero, the entrypoint propagates the failure, and `docker run`
+# itself exits non-zero.
+set +e
+docker run \
+    --name "$INVALID_CONTAINER" \
+    --mount "type=bind,source=${INVALID_DIR},target=/init_doc_db.d,readonly" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --init-data-path /init_doc_db.d \
+    > "${RESULTS_DIR}/${INVALID_CONTAINER}.foreground.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+    fail "invalid init JS rejected" \
+        "container unexpectedly exited 0 with broken init script (log: ${RESULTS_DIR}/${INVALID_CONTAINER}.foreground.log)"
+fi
+if ! grep -Fq "Failed to execute" "${RESULTS_DIR}/${INVALID_CONTAINER}.foreground.log"; then
+    fail "invalid init JS rejected" \
+        "expected 'Failed to execute' in container log: ${RESULTS_DIR}/${INVALID_CONTAINER}.foreground.log"
+fi
+pass "invalid init JS rejected (exit ${exit_code})"
+
+docker rm -f "$INVALID_CONTAINER" >/dev/null 2>&1 || true
+
+echo ""
+echo "All init-data scenarios passed."

--- a/documentdb-local/integration-tests/scenarios/persistence.sh
+++ b/documentdb-local/integration-tests/scenarios/persistence.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# Scenario: persistence.
+#
+# Verifies that data written into a documentdb-local container survives a
+# container restart when the gateway's data directory (/data) is mounted on
+# a host bind volume. The flow is:
+#
+#   1. Start container A with a fresh /data volume, write a known doc and
+#      a custom index into a known collection, stop the container.
+#   2. Start container B against the SAME /data volume (different name,
+#      same image, same password) and verify the doc and index are still
+#      there.
+#
+# Usage:
+#   ./scenarios/persistence.sh <image_ref> [results_dir]
+
+set -euo pipefail
+
+IMAGE_REF="${1:?image reference required as the first argument}"
+RESULTS_DIR="${2:-.test-results/integration-persistence}"
+
+mkdir -p "$RESULTS_DIR"
+
+SUFFIX="$$"
+CONTAINER_A="docdb-persist-a-${SUFFIX}"
+CONTAINER_B="docdb-persist-b-${SUFFIX}"
+
+DOCUMENTDB_USER="docdb_admin"
+DOCUMENTDB_PASSWORD="$(python3 -c \
+    'import secrets, string; print("".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))')"
+
+# A host-owned data directory that both containers will mount as /data.
+DATA_DIR="$(mktemp -d -t docdb-persist-data.XXXXXX)"
+chmod 777 "$DATA_DIR"
+
+cleanup() {
+    for container in "$CONTAINER_A" "$CONTAINER_B"; do
+        if docker ps -a --format '{{.Names}}' | grep -Fxq "$container"; then
+            docker logs "$container" \
+                > "${RESULTS_DIR}/${container}.log" 2>&1 || true
+            docker rm -f "$container" >/dev/null 2>&1 || true
+        fi
+    done
+    # Help docker volumes that may have left root-owned files behind.
+    chmod -R u+rwX "$DATA_DIR" 2>/dev/null || true
+    rm -rf "$DATA_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_ready() {
+    local container="$1"
+    local waited=0
+    local timeout="${2:-240}"
+    while ! docker logs "$container" 2>&1 | grep -Fq "=== DocumentDB is ready ==="; do
+        local running
+        running=$(docker inspect -f '{{.State.Running}}' "$container" \
+            2>/dev/null || echo false)
+        if [ "$running" != "true" ]; then
+            echo "Container ${container} exited before becoming ready." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge "$timeout" ]; then
+            echo "Timed out waiting for ${container} readiness." >&2
+            docker logs "$container" || true
+            return 1
+        fi
+    done
+}
+
+mongosh_eval() {
+    local container="$1"; shift
+    local code="$1"; shift
+    docker exec -i "$container" mongosh \
+        "localhost:10260" \
+        -u "$DOCUMENTDB_USER" -p "$DOCUMENTDB_PASSWORD" \
+        --authenticationMechanism SCRAM-SHA-256 \
+        --tls --tlsAllowInvalidCertificates \
+        --quiet \
+        --eval "$code"
+}
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1: $2" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Phase 1: write data + index into container A on the shared /data volume
+# ---------------------------------------------------------------------------
+
+echo "=== Phase 1: write data into the shared /data volume (container A) ==="
+
+docker run -d \
+    --name "$CONTAINER_A" \
+    --mount "type=bind,source=${DATA_DIR},target=/data" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --skip-init-data >/dev/null
+wait_for_ready "$CONTAINER_A"
+
+mongosh_eval "$CONTAINER_A" '
+  const c = db.getSiblingDB("persist_db").widgets;
+  c.deleteMany({});
+  c.insertMany([
+    { _id: 1, color: "red",   qty: 3 },
+    { _id: 2, color: "green", qty: 5 },
+    { _id: 3, color: "blue",  qty: 7 },
+  ]);
+  c.createIndex({ color: 1 }, { name: "color_persisted" });
+'
+pass "wrote persist_db.widgets and color_persisted index in container A"
+
+# Pre-restart sanity check that the data is visible in container A itself.
+raw=$(mongosh_eval "$CONTAINER_A" \
+    'db.getSiblingDB("persist_db").widgets.countDocuments()')
+got=$(printf '%s' "$raw" | tr -d '\r' | tail -n1)
+[ "$got" = "3" ] || fail "pre-restart count" "expected 3, got $got"
+pass "container A reads 3 widgets back"
+
+# Stop container A but keep the on-disk PG data. `docker stop` gives the
+# entrypoint a SIGTERM, which already handles cleanup, then we remove the
+# container so its name can be reused (we use a different name to be safe).
+docker stop "$CONTAINER_A" >/dev/null
+docker rm -f "$CONTAINER_A" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Phase 2: restart against the same /data volume with container B
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Phase 2: restart against the same /data volume (container B) ==="
+
+docker run -d \
+    --name "$CONTAINER_B" \
+    --mount "type=bind,source=${DATA_DIR},target=/data" \
+    "$IMAGE_REF" \
+    --username "$DOCUMENTDB_USER" \
+    --password "$DOCUMENTDB_PASSWORD" \
+    --skip-init-data >/dev/null
+wait_for_ready "$CONTAINER_B"
+
+raw=$(mongosh_eval "$CONTAINER_B" \
+    'db.getSiblingDB("persist_db").widgets.countDocuments()')
+got=$(printf '%s' "$raw" | tr -d '\r' | tail -n1)
+[ "$got" = "3" ] || fail "widgets survived restart" \
+    "expected 3, got '$got' (raw: $raw)"
+pass "widgets survived restart"
+
+# Inspect documents to be sure we are reading the same content back.
+raw=$(mongosh_eval "$CONTAINER_B" \
+    'JSON.stringify(db.getSiblingDB("persist_db").widgets.find({}, {_id: 1, color: 1}).sort({_id: 1}).toArray())')
+last=$(printf '%s' "$raw" | tr -d '\r' | tail -n1)
+expected='[{"_id":1,"color":"red"},{"_id":2,"color":"green"},{"_id":3,"color":"blue"}]'
+if [ "$last" != "$expected" ]; then
+    fail "widget content matches" "expected $expected, got $last"
+fi
+pass "widget content matches"
+
+# Indexes (other than _id_) are persisted in the catalog and should still
+# be present.
+raw=$(mongosh_eval "$CONTAINER_B" \
+    'JSON.stringify(db.getSiblingDB("persist_db").widgets.getIndexes().map(i => i.name))')
+if ! echo "$raw" | grep -Fq "color_persisted"; then
+    fail "color_persisted index survived restart" "indexes: $raw"
+fi
+pass "color_persisted index survived restart"
+
+# A fresh write after restart should also succeed.
+mongosh_eval "$CONTAINER_B" \
+    'db.getSiblingDB("persist_db").widgets.insertOne({_id: 4, color: "yellow", qty: 1})'
+raw=$(mongosh_eval "$CONTAINER_B" \
+    'db.getSiblingDB("persist_db").widgets.countDocuments()')
+got=$(printf '%s' "$raw" | tr -d '\r' | tail -n1)
+[ "$got" = "4" ] || fail "post-restart write" "expected 4, got $got"
+pass "post-restart write succeeds"
+
+docker rm -f "$CONTAINER_B" >/dev/null
+
+echo ""
+echo "All persistence scenarios passed."

--- a/documentdb-local/integration-tests/tests/00-connectivity.js
+++ b/documentdb-local/integration-tests/tests/00-connectivity.js
@@ -1,0 +1,137 @@
+// Integration tests: connectivity and admin commands.
+// Verifies the gateway responds to ping/hello/buildInfo, that databases and
+// collections are discoverable via listDatabases/listCollections, and that
+// the standard server/db/collection stats commands return the expected shape.
+
+const TEST_FILE = '00-connectivity';
+const DB_NAME = 'it_00_connectivity';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertHas(obj, key, msg) {
+  if (obj === null || obj === undefined || !(key in obj)) {
+    throw new Error((msg || 'assertHas') + ': missing key "' + key +
+      '" in ' + JSON.stringify(obj ? Object.keys(obj) : obj));
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+check('ping returns ok=1', () => {
+  const r = testDb.runCommand({ ping: 1 });
+  assertEq(r.ok, 1, 'ping ok');
+});
+
+check('hello identifies a primary', () => {
+  const r = testDb.runCommand({ hello: 1 });
+  assertEq(r.ok, 1, 'hello ok');
+  // Accept either the modern (isWritablePrimary) or legacy (ismaster) field.
+  assert(r.isWritablePrimary === true || r.ismaster === true,
+    'expected isWritablePrimary or ismaster to be true: ' + JSON.stringify(r));
+  assertHas(r, 'maxBsonObjectSize');
+  assert(typeof r.maxBsonObjectSize === 'number' && r.maxBsonObjectSize > 0,
+    'maxBsonObjectSize should be a positive number');
+});
+
+check('isMaster legacy alias also responds', () => {
+  const r = testDb.runCommand({ isMaster: 1 });
+  assertEq(r.ok, 1, 'isMaster ok');
+});
+
+check('buildInfo returns a version string', () => {
+  const r = testDb.runCommand({ buildInfo: 1 });
+  assertEq(r.ok, 1, 'buildInfo ok');
+  assertHas(r, 'version', 'buildInfo.version');
+  assert(typeof r.version === 'string' && r.version.length > 0,
+    'version not a non-empty string: ' + r.version);
+});
+
+check('connectionStatus returns authInfo', () => {
+  const r = testDb.runCommand({ connectionStatus: 1 });
+  assertEq(r.ok, 1, 'connectionStatus ok');
+  assertHas(r, 'authInfo', 'authInfo');
+});
+
+check('listDatabases includes our test database after a write', () => {
+  testDb.bootstrap_marker.insertOne({ _id: 1, marker: true });
+  const r = db.getSiblingDB('admin').runCommand({ listDatabases: 1 });
+  assertEq(r.ok, 1, 'listDatabases ok');
+  assertHas(r, 'databases', 'databases array');
+  const names = r.databases.map((x) => x.name);
+  assert(names.includes(DB_NAME),
+    'expected ' + DB_NAME + ' in listDatabases names: ' + JSON.stringify(names));
+});
+
+check('listCollections returns the created collection', () => {
+  const cursor = testDb.runCommand({ listCollections: 1 });
+  assertEq(cursor.ok, 1, 'listCollections ok');
+  assertHas(cursor, 'cursor');
+  const names = cursor.cursor.firstBatch.map((c) => c.name);
+  assert(names.includes('bootstrap_marker'),
+    'expected bootstrap_marker in listCollections: ' + JSON.stringify(names));
+});
+
+check('listCollections with name filter narrows results', () => {
+  testDb.other_collection.insertOne({ _id: 1 });
+  const cursor = testDb.runCommand({
+    listCollections: 1,
+    filter: { name: 'bootstrap_marker' },
+  });
+  assertEq(cursor.ok, 1, 'listCollections ok');
+  const names = cursor.cursor.firstBatch.map((c) => c.name);
+  assertEq(names.length, 1, 'filter should narrow to one collection');
+  assertEq(names[0], 'bootstrap_marker');
+});
+
+check('dbStats reports our database name', () => {
+  const r = testDb.runCommand({ dbStats: 1 });
+  assertEq(r.ok, 1, 'dbStats ok');
+  assertEq(r.db, DB_NAME, 'dbStats.db');
+  assertHas(r, 'collections');
+  assertHas(r, 'objects');
+});
+
+check('collStats reports namespace for a populated collection', () => {
+  const r = testDb.runCommand({ collStats: 'bootstrap_marker' });
+  assertEq(r.ok, 1, 'collStats ok');
+  assertHas(r, 'ns', 'collStats.ns');
+  assertEq(r.ns, DB_NAME + '.bootstrap_marker', 'collStats.ns value');
+});
+
+check('currentOp is reachable', () => {
+  const r = db.getSiblingDB('admin').runCommand({ currentOp: 1 });
+  assertEq(r.ok, 1, 'currentOp ok');
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/01-crud.js
+++ b/documentdb-local/integration-tests/tests/01-crud.js
@@ -1,0 +1,328 @@
+// Integration tests: CRUD operations and query operators.
+// Covers insertOne/insertMany, find/findOne with comparison/logical/element/
+// regex/array operators, countDocuments/distinct, updateOne/updateMany/
+// replaceOne, deleteOne/deleteMany, and the findOneAnd* family.
+
+const TEST_FILE = '01-crud';
+const DB_NAME = 'it_01_crud';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertDeepEq(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error((msg || 'assertDeepEq') + ': expected ' + e + ', got ' + a);
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// insert
+// ---------------------------------------------------------------------------
+
+check('insertOne returns the inserted _id', () => {
+  const c = testDb.t_insert;
+  const r = c.insertOne({ _id: 1, name: 'alice', age: 30 });
+  assertEq(r.acknowledged, true, 'acknowledged');
+  assertEq(r.insertedId, 1, 'insertedId');
+  assertEq(c.countDocuments({}), 1, 'count after insertOne');
+});
+
+check('insertMany returns one id per inserted doc', () => {
+  const c = testDb.t_insert_many;
+  const docs = [
+    { _id: 1, v: 'a' },
+    { _id: 2, v: 'b' },
+    { _id: 3, v: 'c' },
+  ];
+  const r = c.insertMany(docs);
+  assertEq(r.acknowledged, true);
+  assertEq(Object.keys(r.insertedIds).length, 3, 'inserted ids length');
+  assertEq(c.countDocuments({}), 3, 'count after insertMany');
+});
+
+check('insertOne with no _id generates an ObjectId', () => {
+  const c = testDb.t_insert_oid;
+  const r = c.insertOne({ name: 'noid' });
+  assert(r.insertedId !== undefined && r.insertedId !== null,
+    'insertedId should be present');
+});
+
+// ---------------------------------------------------------------------------
+// find / findOne / count / distinct
+// ---------------------------------------------------------------------------
+
+const q = testDb.t_query;
+q.insertMany([
+  { _id: 1, name: 'alice', age: 30, city: 'Seattle', tags: ['a', 'b'], active: true },
+  { _id: 2, name: 'bob', age: 25, city: 'Portland', tags: ['b', 'c'], active: false },
+  { _id: 3, name: 'carol', age: 42, city: 'Seattle', tags: ['c', 'd'], active: true },
+  { _id: 4, name: 'dave', age: 35, city: 'NYC', tags: ['d'], active: true, optional: 'x' },
+  { _id: 5, name: 'eve', age: 28, city: 'NYC', tags: [], active: false },
+]);
+
+check('find returns all documents', () => {
+  assertEq(q.find({}).toArray().length, 5);
+});
+
+check('findOne returns a single document', () => {
+  const r = q.findOne({ _id: 1 });
+  assertEq(r.name, 'alice');
+});
+
+check('findOne returns null when no match', () => {
+  const r = q.findOne({ _id: 999 });
+  assertEq(r, null);
+});
+
+check('countDocuments respects a filter', () => {
+  assertEq(q.countDocuments({ city: 'Seattle' }), 2);
+});
+
+check('estimatedDocumentCount returns total count', () => {
+  assertEq(q.estimatedDocumentCount(), 5);
+});
+
+check('distinct returns unique field values', () => {
+  const cities = q.distinct('city').sort();
+  assertDeepEq(cities, ['NYC', 'Portland', 'Seattle']);
+});
+
+// ---------------------------------------------------------------------------
+// Comparison operators
+// ---------------------------------------------------------------------------
+
+check('$eq matches equal value', () => {
+  assertEq(q.countDocuments({ age: { $eq: 30 } }), 1);
+});
+
+check('$ne matches unequal values', () => {
+  assertEq(q.countDocuments({ age: { $ne: 30 } }), 4);
+});
+
+check('$gt matches greater than', () => {
+  assertEq(q.countDocuments({ age: { $gt: 30 } }), 2);
+});
+
+check('$gte matches greater-than-or-equal', () => {
+  assertEq(q.countDocuments({ age: { $gte: 30 } }), 3);
+});
+
+check('$lt matches less than', () => {
+  assertEq(q.countDocuments({ age: { $lt: 30 } }), 2);
+});
+
+check('$lte matches less-than-or-equal', () => {
+  assertEq(q.countDocuments({ age: { $lte: 30 } }), 3);
+});
+
+check('$in matches any of', () => {
+  assertEq(q.countDocuments({ city: { $in: ['Seattle', 'NYC'] } }), 4);
+});
+
+check('$nin matches none of', () => {
+  assertEq(q.countDocuments({ city: { $nin: ['Seattle', 'NYC'] } }), 1);
+});
+
+// ---------------------------------------------------------------------------
+// Logical operators
+// ---------------------------------------------------------------------------
+
+check('$and combines clauses', () => {
+  assertEq(q.countDocuments({ $and: [{ city: 'Seattle' }, { active: true }] }), 2);
+});
+
+check('$or combines clauses', () => {
+  assertEq(q.countDocuments({ $or: [{ age: 25 }, { age: 42 }] }), 2);
+});
+
+check('$nor matches when no clause matches', () => {
+  assertEq(q.countDocuments({ $nor: [{ city: 'Seattle' }, { city: 'NYC' }] }), 1);
+});
+
+check('$not negates a sub-expression', () => {
+  assertEq(q.countDocuments({ age: { $not: { $gte: 30 } } }), 2);
+});
+
+// ---------------------------------------------------------------------------
+// Element and evaluation operators
+// ---------------------------------------------------------------------------
+
+check('$exists true matches docs with field present', () => {
+  assertEq(q.countDocuments({ optional: { $exists: true } }), 1);
+});
+
+check('$exists false matches docs without field', () => {
+  assertEq(q.countDocuments({ optional: { $exists: false } }), 4);
+});
+
+check('$type matches by BSON type name', () => {
+  assertEq(q.countDocuments({ active: { $type: 'bool' } }), 5);
+});
+
+check('$regex matches by pattern', () => {
+  assertEq(q.countDocuments({ name: { $regex: '^a' } }), 1);
+});
+
+check('regex literal matches by pattern', () => {
+  assertEq(q.countDocuments({ name: /o/ }), 2);
+});
+
+// ---------------------------------------------------------------------------
+// Array operators
+// ---------------------------------------------------------------------------
+
+check('$all matches when all array values present', () => {
+  assertEq(q.countDocuments({ tags: { $all: ['b', 'c'] } }), 1);
+});
+
+check('$size matches array length', () => {
+  assertEq(q.countDocuments({ tags: { $size: 0 } }), 1);
+});
+
+check('$elemMatch matches element-by-element', () => {
+  const c = testDb.t_elemmatch;
+  c.insertMany([
+    { _id: 1, scores: [{ s: 80 }, { s: 95 }] },
+    { _id: 2, scores: [{ s: 60 }, { s: 70 }] },
+  ]);
+  assertEq(c.countDocuments({ scores: { $elemMatch: { s: { $gt: 90 } } } }), 1);
+});
+
+// ---------------------------------------------------------------------------
+// Update operations
+// ---------------------------------------------------------------------------
+
+check('updateOne with $set modifies one document', () => {
+  const c = testDb.t_update_one;
+  c.insertOne({ _id: 1, v: 'a' });
+  const r = c.updateOne({ _id: 1 }, { $set: { v: 'A' } });
+  assertEq(r.matchedCount, 1);
+  assertEq(r.modifiedCount, 1);
+  assertEq(c.findOne({ _id: 1 }).v, 'A');
+});
+
+check('updateMany with $set modifies all matches', () => {
+  const c = testDb.t_update_many;
+  c.insertMany([{ _id: 1, g: 'a' }, { _id: 2, g: 'a' }, { _id: 3, g: 'b' }]);
+  const r = c.updateMany({ g: 'a' }, { $set: { g: 'A' } });
+  assertEq(r.matchedCount, 2);
+  assertEq(r.modifiedCount, 2);
+  assertEq(c.countDocuments({ g: 'A' }), 2);
+});
+
+check('replaceOne replaces the whole document (except _id)', () => {
+  const c = testDb.t_replace;
+  c.insertOne({ _id: 1, a: 1, b: 2 });
+  const r = c.replaceOne({ _id: 1 }, { c: 3 });
+  assertEq(r.matchedCount, 1);
+  assertEq(r.modifiedCount, 1);
+  const after = c.findOne({ _id: 1 });
+  assertEq(after.c, 3);
+  assert(!('a' in after) && !('b' in after),
+    'old fields should be gone: ' + JSON.stringify(after));
+});
+
+check('upsert inserts when no match exists', () => {
+  const c = testDb.t_upsert;
+  const r = c.updateOne({ _id: 100 }, { $set: { v: 'new' } }, { upsert: true });
+  assertEq(r.matchedCount, 0);
+  assertEq(r.upsertedCount, 1);
+  assertEq(c.findOne({ _id: 100 }).v, 'new');
+});
+
+// ---------------------------------------------------------------------------
+// Delete operations
+// ---------------------------------------------------------------------------
+
+check('deleteOne removes one document', () => {
+  const c = testDb.t_delete_one;
+  c.insertMany([{ _id: 1 }, { _id: 2 }, { _id: 3 }]);
+  const r = c.deleteOne({ _id: 2 });
+  assertEq(r.deletedCount, 1);
+  assertEq(c.countDocuments({}), 2);
+});
+
+check('deleteMany removes all matching documents', () => {
+  const c = testDb.t_delete_many;
+  c.insertMany([{ _id: 1, g: 'a' }, { _id: 2, g: 'a' }, { _id: 3, g: 'b' }]);
+  const r = c.deleteMany({ g: 'a' });
+  assertEq(r.deletedCount, 2);
+  assertEq(c.countDocuments({}), 1);
+});
+
+// ---------------------------------------------------------------------------
+// findOneAnd* family
+// ---------------------------------------------------------------------------
+
+check('findOneAndUpdate returns the document before update by default', () => {
+  const c = testDb.t_foau;
+  c.insertOne({ _id: 1, v: 'old' });
+  const before = c.findOneAndUpdate({ _id: 1 }, { $set: { v: 'new' } });
+  assertEq(before.v, 'old');
+  assertEq(c.findOne({ _id: 1 }).v, 'new');
+});
+
+check('findOneAndUpdate with returnDocument:after returns the new doc', () => {
+  const c = testDb.t_foau_after;
+  c.insertOne({ _id: 1, v: 'old' });
+  const after = c.findOneAndUpdate(
+    { _id: 1 },
+    { $set: { v: 'new' } },
+    { returnDocument: 'after' },
+  );
+  assertEq(after.v, 'new');
+});
+
+check('findOneAndReplace replaces and returns the previous document', () => {
+  const c = testDb.t_foar;
+  c.insertOne({ _id: 1, a: 1 });
+  const before = c.findOneAndReplace({ _id: 1 }, { b: 2 });
+  assertEq(before.a, 1);
+  const after = c.findOne({ _id: 1 });
+  assertEq(after.b, 2);
+  assert(!('a' in after), 'old fields should be removed');
+});
+
+check('findOneAndDelete removes and returns the deleted document', () => {
+  const c = testDb.t_foad;
+  c.insertOne({ _id: 1, v: 'x' });
+  const removed = c.findOneAndDelete({ _id: 1 });
+  assertEq(removed.v, 'x');
+  assertEq(c.findOne({ _id: 1 }), null);
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/02-update-operators.js
+++ b/documentdb-local/integration-tests/tests/02-update-operators.js
@@ -1,0 +1,265 @@
+// Integration tests: update operators.
+// Covers the field update operators ($set, $unset, $inc, $mul, $min, $max,
+// $rename, $currentDate, $setOnInsert) and the array update operators
+// ($push, $pop, $pull, $pullAll, $addToSet) including their modifiers
+// ($each, $sort, $slice, $position), plus the positional update operators.
+
+const TEST_FILE = '02-update-operators';
+const DB_NAME = 'it_02_update_operators';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertDeepEq(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error((msg || 'assertDeepEq') + ': expected ' + e + ', got ' + a);
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// Field operators
+// ---------------------------------------------------------------------------
+
+check('$set creates a missing field', () => {
+  const c = testDb.t_set_new;
+  c.insertOne({ _id: 1 });
+  c.updateOne({ _id: 1 }, { $set: { added: 'x' } });
+  assertEq(c.findOne({ _id: 1 }).added, 'x');
+});
+
+check('$set overwrites an existing field', () => {
+  const c = testDb.t_set_over;
+  c.insertOne({ _id: 1, v: 'old' });
+  c.updateOne({ _id: 1 }, { $set: { v: 'new' } });
+  assertEq(c.findOne({ _id: 1 }).v, 'new');
+});
+
+check('$unset removes a field', () => {
+  const c = testDb.t_unset;
+  c.insertOne({ _id: 1, keep: 1, drop: 2 });
+  c.updateOne({ _id: 1 }, { $unset: { drop: '' } });
+  const doc = c.findOne({ _id: 1 });
+  assert('keep' in doc, 'keep should remain');
+  assert(!('drop' in doc), 'drop should be removed');
+});
+
+check('$inc increments a numeric field', () => {
+  const c = testDb.t_inc;
+  c.insertOne({ _id: 1, n: 10 });
+  c.updateOne({ _id: 1 }, { $inc: { n: 5 } });
+  assertEq(c.findOne({ _id: 1 }).n, 15);
+});
+
+check('$inc on missing field creates it', () => {
+  const c = testDb.t_inc_new;
+  c.insertOne({ _id: 1 });
+  c.updateOne({ _id: 1 }, { $inc: { n: 3 } });
+  assertEq(c.findOne({ _id: 1 }).n, 3);
+});
+
+check('$mul multiplies a numeric field', () => {
+  const c = testDb.t_mul;
+  c.insertOne({ _id: 1, n: 4 });
+  c.updateOne({ _id: 1 }, { $mul: { n: 3 } });
+  assertEq(c.findOne({ _id: 1 }).n, 12);
+});
+
+check('$min keeps the smaller value', () => {
+  const c = testDb.t_min;
+  c.insertOne({ _id: 1, n: 10 });
+  c.updateOne({ _id: 1 }, { $min: { n: 5 } });
+  assertEq(c.findOne({ _id: 1 }).n, 5);
+  c.updateOne({ _id: 1 }, { $min: { n: 50 } });
+  assertEq(c.findOne({ _id: 1 }).n, 5, '$min should not overwrite smaller value');
+});
+
+check('$max keeps the larger value', () => {
+  const c = testDb.t_max;
+  c.insertOne({ _id: 1, n: 5 });
+  c.updateOne({ _id: 1 }, { $max: { n: 10 } });
+  assertEq(c.findOne({ _id: 1 }).n, 10);
+  c.updateOne({ _id: 1 }, { $max: { n: 1 } });
+  assertEq(c.findOne({ _id: 1 }).n, 10, '$max should not overwrite larger value');
+});
+
+check('$rename changes a field name', () => {
+  const c = testDb.t_rename;
+  c.insertOne({ _id: 1, oldName: 'value' });
+  c.updateOne({ _id: 1 }, { $rename: { oldName: 'newName' } });
+  const doc = c.findOne({ _id: 1 });
+  assert(!('oldName' in doc), 'oldName should be gone');
+  assertEq(doc.newName, 'value');
+});
+
+check('$currentDate sets a Date value', () => {
+  const c = testDb.t_currentdate;
+  c.insertOne({ _id: 1 });
+  c.updateOne({ _id: 1 }, { $currentDate: { ts: true } });
+  const doc = c.findOne({ _id: 1 });
+  assert(doc.ts instanceof Date,
+    '$currentDate should yield a Date, got: ' + typeof doc.ts);
+});
+
+check('$setOnInsert applies only on upsert insert', () => {
+  const c = testDb.t_setoninsert;
+  // Upsert path: no match exists, so $setOnInsert should apply.
+  c.updateOne(
+    { _id: 1 },
+    { $set: { changeable: 'first' }, $setOnInsert: { createdBy: 'init' } },
+    { upsert: true },
+  );
+  let doc = c.findOne({ _id: 1 });
+  assertEq(doc.createdBy, 'init', 'createdBy from $setOnInsert');
+  assertEq(doc.changeable, 'first');
+
+  // Match path: $setOnInsert should NOT modify createdBy.
+  c.updateOne(
+    { _id: 1 },
+    { $set: { changeable: 'second' }, $setOnInsert: { createdBy: 'CHANGED' } },
+    { upsert: true },
+  );
+  doc = c.findOne({ _id: 1 });
+  assertEq(doc.createdBy, 'init', '$setOnInsert must not run on match');
+  assertEq(doc.changeable, 'second');
+});
+
+// ---------------------------------------------------------------------------
+// Array operators
+// ---------------------------------------------------------------------------
+
+check('$push appends one element', () => {
+  const c = testDb.t_push;
+  c.insertOne({ _id: 1, items: ['a'] });
+  c.updateOne({ _id: 1 }, { $push: { items: 'b' } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'b']);
+});
+
+check('$push with $each appends multiple elements', () => {
+  const c = testDb.t_push_each;
+  c.insertOne({ _id: 1, items: ['a'] });
+  c.updateOne({ _id: 1 }, { $push: { items: { $each: ['b', 'c'] } } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'b', 'c']);
+});
+
+check('$push with $each + $sort sorts after appending', () => {
+  const c = testDb.t_push_sort;
+  c.insertOne({ _id: 1, nums: [3, 1] });
+  c.updateOne(
+    { _id: 1 },
+    { $push: { nums: { $each: [4, 2], $sort: 1 } } },
+  );
+  assertDeepEq(c.findOne({ _id: 1 }).nums, [1, 2, 3, 4]);
+});
+
+check('$push with $each + $slice truncates', () => {
+  const c = testDb.t_push_slice;
+  c.insertOne({ _id: 1, items: ['a', 'b'] });
+  c.updateOne(
+    { _id: 1 },
+    { $push: { items: { $each: ['c', 'd', 'e'], $slice: -3 } } },
+  );
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['c', 'd', 'e']);
+});
+
+check('$pop -1 removes the first element', () => {
+  const c = testDb.t_pop_first;
+  c.insertOne({ _id: 1, items: ['a', 'b', 'c'] });
+  c.updateOne({ _id: 1 }, { $pop: { items: -1 } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['b', 'c']);
+});
+
+check('$pop 1 removes the last element', () => {
+  const c = testDb.t_pop_last;
+  c.insertOne({ _id: 1, items: ['a', 'b', 'c'] });
+  c.updateOne({ _id: 1 }, { $pop: { items: 1 } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'b']);
+});
+
+check('$pull removes matching elements', () => {
+  const c = testDb.t_pull;
+  c.insertOne({ _id: 1, items: ['a', 'b', 'a', 'c'] });
+  c.updateOne({ _id: 1 }, { $pull: { items: 'a' } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['b', 'c']);
+});
+
+check('$pullAll removes any of multiple values', () => {
+  const c = testDb.t_pullall;
+  c.insertOne({ _id: 1, items: ['a', 'b', 'c', 'd'] });
+  c.updateOne({ _id: 1 }, { $pullAll: { items: ['b', 'd'] } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'c']);
+});
+
+check('$addToSet adds only when not present', () => {
+  const c = testDb.t_addtoset;
+  c.insertOne({ _id: 1, items: ['a', 'b'] });
+  c.updateOne({ _id: 1 }, { $addToSet: { items: 'a' } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'b'], 'duplicate not added');
+  c.updateOne({ _id: 1 }, { $addToSet: { items: 'c' } });
+  assertDeepEq(c.findOne({ _id: 1 }).items, ['a', 'b', 'c']);
+});
+
+check('$addToSet with $each adds multiple distinct values', () => {
+  const c = testDb.t_addtoset_each;
+  c.insertOne({ _id: 1, items: ['a'] });
+  c.updateOne({ _id: 1 }, { $addToSet: { items: { $each: ['a', 'b', 'c'] } } });
+  assertDeepEq(c.findOne({ _id: 1 }).items.sort(), ['a', 'b', 'c']);
+});
+
+// ---------------------------------------------------------------------------
+// Positional operators
+// ---------------------------------------------------------------------------
+
+check('$ positional updates the matched array element', () => {
+  const c = testDb.t_positional;
+  c.insertOne({ _id: 1, scores: [{ id: 'a', n: 10 }, { id: 'b', n: 20 }] });
+  c.updateOne(
+    { _id: 1, 'scores.id': 'b' },
+    { $set: { 'scores.$.n': 99 } },
+  );
+  const doc = c.findOne({ _id: 1 });
+  assertEq(doc.scores[0].n, 10);
+  assertEq(doc.scores[1].n, 99);
+});
+
+check('$[] applies to all array elements', () => {
+  const c = testDb.t_all_positional;
+  c.insertOne({ _id: 1, nums: [1, 2, 3] });
+  c.updateOne({ _id: 1 }, { $inc: { 'nums.$[]': 10 } });
+  assertDeepEq(c.findOne({ _id: 1 }).nums, [11, 12, 13]);
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/03-indexes.js
+++ b/documentdb-local/integration-tests/tests/03-indexes.js
@@ -1,0 +1,205 @@
+// Integration tests: indexes.
+// Covers createIndex variants (single field, compound, unique, sparse,
+// partial, TTL, multikey), listIndexes, getIndexes, dropIndex by name and
+// by spec, dropIndexes, and verifies unique-constraint enforcement.
+
+const TEST_FILE = '03-indexes';
+const DB_NAME = 'it_03_indexes';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertThrows(fn, msg) {
+  let threw = false;
+  try { fn(); } catch (e) { threw = true; }
+  if (!threw) throw new Error((msg || 'assertThrows') + ': expected an exception');
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+function findIndex(c, name) {
+  return c.getIndexes().find((i) => i.name === name);
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// Default index
+// ---------------------------------------------------------------------------
+
+check('every collection starts with an _id index', () => {
+  const c = testDb.t_default;
+  c.insertOne({ _id: 1 });
+  const idx = findIndex(c, '_id_');
+  assert(idx !== undefined, '_id_ index should exist');
+});
+
+// ---------------------------------------------------------------------------
+// Single-field and compound indexes
+// ---------------------------------------------------------------------------
+
+check('single-field index is created and listed', () => {
+  const c = testDb.t_single;
+  c.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  c.createIndex({ a: 1 }, { name: 'a_1' });
+  const idx = findIndex(c, 'a_1');
+  assert(idx !== undefined, 'a_1 should be present');
+});
+
+check('compound index is created and listed', () => {
+  const c = testDb.t_compound;
+  c.insertMany([{ a: 1, b: 'x' }, { a: 2, b: 'y' }]);
+  c.createIndex({ a: 1, b: -1 }, { name: 'a_1_b_-1' });
+  const idx = findIndex(c, 'a_1_b_-1');
+  assert(idx !== undefined, 'compound index should be present');
+});
+
+check('listIndexes command returns at least the _id index', () => {
+  const c = testDb.t_single;
+  const r = testDb.runCommand({ listIndexes: 't_single' });
+  assertEq(r.ok, 1, 'listIndexes ok');
+  const names = r.cursor.firstBatch.map((i) => i.name);
+  assert(names.includes('_id_'), '_id_ should be returned');
+});
+
+// ---------------------------------------------------------------------------
+// Unique indexes
+// ---------------------------------------------------------------------------
+
+check('unique index permits a single document per value', () => {
+  const c = testDb.t_unique;
+  c.createIndex({ email: 1 }, { name: 'email_unique', unique: true });
+  c.insertOne({ _id: 1, email: 'a@example.com' });
+  c.insertOne({ _id: 2, email: 'b@example.com' });
+  assertEq(c.countDocuments({}), 2);
+});
+
+check('unique index rejects a duplicate value', () => {
+  const c = testDb.t_unique;
+  assertThrows(
+    () => c.insertOne({ _id: 3, email: 'a@example.com' }),
+    'duplicate insert should throw',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Sparse and partial indexes
+// ---------------------------------------------------------------------------
+
+check('sparse index excludes documents missing the field', () => {
+  const c = testDb.t_sparse;
+  c.insertMany([
+    { _id: 1, opt: 'present' },
+    { _id: 2 },
+  ]);
+  c.createIndex({ opt: 1 }, { name: 'opt_sparse', sparse: true });
+  const idx = findIndex(c, 'opt_sparse');
+  assert(idx !== undefined && idx.sparse === true,
+    'sparse flag should be set: ' + JSON.stringify(idx));
+});
+
+check('partial index records partialFilterExpression', () => {
+  const c = testDb.t_partial;
+  c.insertMany([
+    { _id: 1, status: 'active', s: 'a' },
+    { _id: 2, status: 'inactive', s: 'b' },
+  ]);
+  c.createIndex(
+    { s: 1 },
+    { name: 's_partial', partialFilterExpression: { status: 'active' } },
+  );
+  const idx = findIndex(c, 's_partial');
+  assert(idx !== undefined && idx.partialFilterExpression !== undefined,
+    'partialFilterExpression should be recorded: ' + JSON.stringify(idx));
+});
+
+// ---------------------------------------------------------------------------
+// TTL index
+// ---------------------------------------------------------------------------
+
+check('TTL index records expireAfterSeconds', () => {
+  const c = testDb.t_ttl;
+  c.createIndex(
+    { createdAt: 1 },
+    { name: 'createdAt_ttl', expireAfterSeconds: 60 },
+  );
+  const idx = findIndex(c, 'createdAt_ttl');
+  assert(idx !== undefined, 'TTL index should be present');
+  assertEq(idx.expireAfterSeconds, 60, 'expireAfterSeconds');
+});
+
+// ---------------------------------------------------------------------------
+// Multikey (array field) index
+// ---------------------------------------------------------------------------
+
+check('multikey index supports array-element queries', () => {
+  const c = testDb.t_multikey;
+  c.insertMany([
+    { _id: 1, tags: ['a', 'b'] },
+    { _id: 2, tags: ['b', 'c'] },
+    { _id: 3, tags: ['d'] },
+  ]);
+  c.createIndex({ tags: 1 }, { name: 'tags_1' });
+  assertEq(c.countDocuments({ tags: 'b' }), 2);
+});
+
+// ---------------------------------------------------------------------------
+// dropIndex variants
+// ---------------------------------------------------------------------------
+
+check('dropIndex by name removes the index', () => {
+  const c = testDb.t_drop_by_name;
+  c.createIndex({ a: 1 }, { name: 'a_idx' });
+  c.dropIndex('a_idx');
+  assert(findIndex(c, 'a_idx') === undefined,
+    'a_idx should be removed: ' + JSON.stringify(c.getIndexes()));
+});
+
+check('dropIndex by key spec removes the index', () => {
+  const c = testDb.t_drop_by_spec;
+  c.createIndex({ b: 1 });
+  c.dropIndex({ b: 1 });
+  const names = c.getIndexes().map((i) => i.name);
+  assert(!names.some((n) => n.startsWith('b_')),
+    'b index should be removed: ' + JSON.stringify(names));
+});
+
+check('dropIndexes wildcard removes everything except _id', () => {
+  const c = testDb.t_drop_all;
+  c.createIndex({ a: 1 });
+  c.createIndex({ b: 1 });
+  c.dropIndexes('*');
+  const names = c.getIndexes().map((i) => i.name);
+  assertEq(names.length, 1, 'only _id should remain');
+  assertEq(names[0], '_id_');
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/04-aggregation.js
+++ b/documentdb-local/integration-tests/tests/04-aggregation.js
@@ -1,0 +1,455 @@
+// Integration tests: aggregation pipeline.
+// Covers a broad selection of pipeline stages, expression operators, and
+// group accumulators. The features exercised here are the subset listed in
+// documentdb-local/functional-tests/config/allowlist.yml so they stay green
+// across PG 15-18.
+
+const TEST_FILE = '04-aggregation';
+const DB_NAME = 'it_04_aggregation';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertDeepEq(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error((msg || 'assertDeepEq') + ': expected ' + e + ', got ' + a);
+  }
+}
+function assertApproxEq(actual, expected, tol, msg) {
+  if (typeof actual !== 'number') {
+    throw new Error((msg || 'assertApproxEq') + ': not a number: ' + actual);
+  }
+  if (Math.abs(actual - expected) > tol) {
+    throw new Error((msg || 'assertApproxEq') + ': expected ' + expected +
+      ' +/- ' + tol + ', got ' + actual);
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+const sales = testDb.sales;
+sales.insertMany([
+  { _id: 1, region: 'west', product: 'apple',  qty: 3,  price: 1.0, date: new Date('2024-01-15') },
+  { _id: 2, region: 'west', product: 'banana', qty: 5,  price: 0.5, date: new Date('2024-02-10') },
+  { _id: 3, region: 'east', product: 'apple',  qty: 10, price: 1.2, date: new Date('2024-02-20') },
+  { _id: 4, region: 'east', product: 'cherry', qty: 7,  price: 2.0, date: new Date('2024-03-05') },
+  { _id: 5, region: 'south', product: 'apple', qty: 2,  price: 1.5, date: new Date('2024-03-22') },
+]);
+
+// ---------------------------------------------------------------------------
+// Stages: $match, $project, $sort, $skip, $limit
+// ---------------------------------------------------------------------------
+
+check('$match filters by predicate', () => {
+  const r = sales.aggregate([{ $match: { region: 'west' } }]).toArray();
+  assertEq(r.length, 2);
+});
+
+check('$project with inclusion + computed field', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    { $project: { _id: 0, product: 1, total: { $multiply: ['$qty', '$price'] } } },
+  ]).toArray();
+  assertEq(r.length, 1);
+  assertDeepEq(r[0], { product: 'apple', total: 3 });
+});
+
+check('$sort + $skip + $limit paginate results', () => {
+  const r = sales.aggregate([
+    { $sort: { qty: 1 } },
+    { $skip: 1 },
+    { $limit: 2 },
+  ]).toArray();
+  assertEq(r.length, 2);
+  assertEq(r[0]._id, 1);
+  assertEq(r[1]._id, 2);
+});
+
+check('$count returns a single document with the count', () => {
+  const r = sales.aggregate([{ $count: 'n' }]).toArray();
+  assertEq(r.length, 1);
+  assertEq(r[0].n, 5);
+});
+
+// ---------------------------------------------------------------------------
+// $unwind variants
+// ---------------------------------------------------------------------------
+
+check('$unwind expands an array field', () => {
+  const c = testDb.with_arrays;
+  c.insertMany([
+    { _id: 1, tags: ['a', 'b', 'c'] },
+    { _id: 2, tags: [] },
+  ]);
+  const r = c.aggregate([{ $unwind: '$tags' }]).toArray();
+  assertEq(r.length, 3);
+});
+
+check('$unwind with preserveNullAndEmptyArrays keeps empty arrays', () => {
+  const c = testDb.with_arrays;
+  const r = c.aggregate([
+    { $unwind: { path: '$tags', preserveNullAndEmptyArrays: true } },
+  ]).toArray();
+  assertEq(r.length, 4, 'one extra row for the empty array');
+});
+
+check('$unwind with includeArrayIndex adds the index field', () => {
+  const c = testDb.with_arrays;
+  const r = c.aggregate([
+    { $match: { _id: 1 } },
+    { $unwind: { path: '$tags', includeArrayIndex: 'idx' } },
+    { $sort: { idx: 1 } },
+  ]).toArray();
+  assertDeepEq(r.map((x) => Number(x.idx)), [0, 1, 2]);
+});
+
+// ---------------------------------------------------------------------------
+// $addFields, $set, $unset, $replaceRoot
+// ---------------------------------------------------------------------------
+
+check('$addFields injects a new field', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    { $addFields: { total: { $multiply: ['$qty', '$price'] } } },
+  ]).toArray();
+  assertEq(r[0].total, 3);
+});
+
+check('$set is an alias for $addFields', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 2 } },
+    { $set: { total: { $multiply: ['$qty', '$price'] } } },
+  ]).toArray();
+  assertEq(r[0].total, 2.5);
+});
+
+check('$unset drops fields', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    { $unset: ['price', 'date'] },
+  ]).toArray();
+  assert(!('price' in r[0]) && !('date' in r[0]),
+    'price and date should be removed: ' + JSON.stringify(r[0]));
+});
+
+check('$replaceRoot promotes an embedded document', () => {
+  const c = testDb.with_nested;
+  c.insertOne({ _id: 1, inner: { a: 1, b: 2 } });
+  const r = c.aggregate([{ $replaceRoot: { newRoot: '$inner' } }]).toArray();
+  assertDeepEq(r[0], { a: 1, b: 2 });
+});
+
+// ---------------------------------------------------------------------------
+// $group with various accumulators
+// ---------------------------------------------------------------------------
+
+check('$group with $sum and $avg', () => {
+  const r = sales.aggregate([
+    {
+      $group: {
+        _id: '$region',
+        totalQty: { $sum: '$qty' },
+        avgQty: { $avg: '$qty' },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  const east = r.find((x) => x._id === 'east');
+  assertEq(east.totalQty, 17);
+  assertApproxEq(east.avgQty, 8.5, 1e-9);
+});
+
+check('$group with $min and $max', () => {
+  const r = sales.aggregate([
+    {
+      $group: {
+        _id: null,
+        minQty: { $min: '$qty' },
+        maxQty: { $max: '$qty' },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].minQty, 2);
+  assertEq(r[0].maxQty, 10);
+});
+
+check('$group with $first and $last after $sort', () => {
+  const r = sales.aggregate([
+    { $sort: { qty: 1 } },
+    {
+      $group: {
+        _id: null,
+        smallest: { $first: '$product' },
+        largest: { $last: '$product' },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].smallest, 'apple');
+  assertEq(r[0].largest, 'apple');
+});
+
+check('$group with $push collects values', () => {
+  const r = sales.aggregate([
+    { $sort: { _id: 1 } },
+    { $group: { _id: '$region', products: { $push: '$product' } } },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  const east = r.find((x) => x._id === 'east');
+  assertDeepEq(east.products.sort(), ['apple', 'cherry']);
+});
+
+check('$group with $addToSet deduplicates values', () => {
+  const r = sales.aggregate([
+    { $group: { _id: null, products: { $addToSet: '$product' } } },
+  ]).toArray();
+  assertDeepEq(r[0].products.sort(), ['apple', 'banana', 'cherry']);
+});
+
+check('$group with $stdDevPop and $stdDevSamp produce numbers', () => {
+  const r = sales.aggregate([
+    {
+      $group: {
+        _id: null,
+        sdp: { $stdDevPop: '$qty' },
+        sds: { $stdDevSamp: '$qty' },
+      },
+    },
+  ]).toArray();
+  assert(typeof r[0].sdp === 'number' && r[0].sdp >= 0,
+    '$stdDevPop should be a non-negative number: ' + r[0].sdp);
+  assert(typeof r[0].sds === 'number' && r[0].sds >= 0,
+    '$stdDevSamp should be a non-negative number: ' + r[0].sds);
+});
+
+// ---------------------------------------------------------------------------
+// $facet, $bucket, $bucketAuto, $sortByCount, $sample
+// ---------------------------------------------------------------------------
+
+check('$facet runs multiple sub-pipelines in parallel', () => {
+  const r = sales.aggregate([
+    {
+      $facet: {
+        byRegion: [{ $group: { _id: '$region', n: { $sum: 1 } } }],
+        total: [{ $count: 'n' }],
+      },
+    },
+  ]).toArray();
+  assertEq(r.length, 1);
+  assert(Array.isArray(r[0].byRegion) && r[0].byRegion.length === 3,
+    'byRegion should have 3 entries');
+  assertEq(r[0].total[0].n, 5);
+});
+
+check('$bucket groups numeric values into explicit boundaries', () => {
+  const r = sales.aggregate([
+    {
+      $bucket: {
+        groupBy: '$qty',
+        boundaries: [0, 5, 10, 20],
+        default: 'other',
+        output: { n: { $sum: 1 } },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  // 0..4: qty in {3, 2}; 5..9: qty in {5, 7}; 10..19: qty in {10}
+  assertDeepEq(r.map((x) => ({ b: x._id, n: x.n })), [
+    { b: 0, n: 2 },
+    { b: 5, n: 2 },
+    { b: 10, n: 1 },
+  ]);
+});
+
+check('$bucketAuto splits into N approximately equal buckets', () => {
+  const r = sales.aggregate([
+    { $bucketAuto: { groupBy: '$qty', buckets: 2 } },
+  ]).toArray();
+  assertEq(r.length, 2);
+  const total = r.reduce((acc, b) => acc + b.count, 0);
+  assertEq(total, 5);
+});
+
+check('$sortByCount returns counts in descending order', () => {
+  const r = sales.aggregate([{ $sortByCount: '$region' }]).toArray();
+  assertEq(r.length, 3);
+  // Counts must be monotonically non-increasing.
+  for (let i = 1; i < r.length; i++) {
+    assert(r[i - 1].count >= r[i].count,
+      'counts should be non-increasing: ' + JSON.stringify(r));
+  }
+});
+
+check('$sample returns at most size docs', () => {
+  const r = sales.aggregate([{ $sample: { size: 3 } }]).toArray();
+  assert(r.length <= 3, 'sample size should be respected');
+});
+
+// ---------------------------------------------------------------------------
+// $lookup
+// ---------------------------------------------------------------------------
+
+check('$lookup joins on a foreign field', () => {
+  const products = testDb.products;
+  products.insertMany([
+    { _id: 'apple',  category: 'fruit' },
+    { _id: 'banana', category: 'fruit' },
+    { _id: 'cherry', category: 'fruit' },
+  ]);
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    {
+      $lookup: {
+        from: 'products',
+        localField: 'product',
+        foreignField: '_id',
+        as: 'productDoc',
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].productDoc.length, 1);
+  assertEq(r[0].productDoc[0].category, 'fruit');
+});
+
+// ---------------------------------------------------------------------------
+// Expression operators (arithmetic / string / array / date / conditional)
+// ---------------------------------------------------------------------------
+
+check('arithmetic expressions: $add / $subtract / $multiply / $divide / $mod', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 4 } },
+    {
+      $project: {
+        _id: 0,
+        sum: { $add: ['$qty', '$price'] },
+        diff: { $subtract: ['$qty', '$price'] },
+        prod: { $multiply: ['$qty', '$price'] },
+        quot: { $divide: ['$qty', '$price'] },
+        mod3: { $mod: ['$qty', 3] },
+      },
+    },
+  ]).toArray();
+  assertApproxEq(r[0].sum, 9, 1e-9);
+  assertApproxEq(r[0].diff, 5, 1e-9);
+  assertApproxEq(r[0].prod, 14, 1e-9);
+  assertApproxEq(r[0].quot, 3.5, 1e-9);
+  assertEq(r[0].mod3, 1);
+});
+
+check('arithmetic expressions: $abs / $ceil / $floor', () => {
+  const c = testDb.numbers;
+  c.insertMany([{ _id: 1, n: -3.2 }]);
+  const r = c.aggregate([
+    { $project: { _id: 0, abs: { $abs: '$n' }, ceil: { $ceil: '$n' }, floor: { $floor: '$n' } } },
+  ]).toArray();
+  assertApproxEq(r[0].abs, 3.2, 1e-9);
+  assertEq(r[0].ceil, -3);
+  assertEq(r[0].floor, -4);
+});
+
+check('string expressions: $concat / $toUpper / $toLower / $strLenCP', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    {
+      $project: {
+        _id: 0,
+        upper: { $toUpper: '$product' },
+        lower: { $toLower: '$region' },
+        concat: { $concat: ['$region', ':', '$product'] },
+        len: { $strLenCP: '$product' },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].upper, 'APPLE');
+  assertEq(r[0].lower, 'west');
+  assertEq(r[0].concat, 'west:apple');
+  assertEq(r[0].len, 5);
+});
+
+check('array expressions: $size / $arrayElemAt / $concatArrays', () => {
+  const c = testDb.arr_ops;
+  c.insertOne({ _id: 1, a: [1, 2, 3], b: [4, 5] });
+  const r = c.aggregate([
+    {
+      $project: {
+        _id: 0,
+        sz: { $size: '$a' },
+        first: { $arrayElemAt: ['$a', 0] },
+        joined: { $concatArrays: ['$a', '$b'] },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].sz, 3);
+  assertEq(r[0].first, 1);
+  assertDeepEq(r[0].joined, [1, 2, 3, 4, 5]);
+});
+
+check('date expressions: $year / $month / $dayOfMonth', () => {
+  const r = sales.aggregate([
+    { $match: { _id: 1 } },
+    {
+      $project: {
+        _id: 0,
+        y: { $year: '$date' },
+        m: { $month: '$date' },
+        d: { $dayOfMonth: '$date' },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].y, 2024);
+  assertEq(r[0].m, 1);
+  assertEq(r[0].d, 15);
+});
+
+check('conditional expressions: $cond / $ifNull', () => {
+  const c = testDb.maybe;
+  c.insertMany([
+    { _id: 1, x: 10 },
+    { _id: 2 },
+  ]);
+  const r = c.aggregate([
+    { $sort: { _id: 1 } },
+    {
+      $project: {
+        _id: 1,
+        kind: { $cond: [{ $gte: ['$x', 5] }, 'big', 'small'] },
+        xOrZero: { $ifNull: ['$x', 0] },
+      },
+    },
+  ]).toArray();
+  assertEq(r[0].kind, 'big');
+  assertEq(r[1].xOrZero, 0);
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/05-collection-and-database.js
+++ b/documentdb-local/integration-tests/tests/05-collection-and-database.js
@@ -1,0 +1,171 @@
+// Integration tests: collection and database management.
+// Covers createCollection (with validators), listCollections, drop,
+// renameCollection (within a database), dropDatabase, and view creation /
+// query / drop. Capped collections and transactions are intentionally not
+// exercised - the upstream functional gate covers them where supported.
+
+const TEST_FILE = '05-collection-and-database';
+const DB_NAME = 'it_05_collection_and_database';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertThrows(fn, msg) {
+  let threw = false;
+  try { fn(); } catch (e) { threw = true; }
+  if (!threw) throw new Error((msg || 'assertThrows') + ': expected an exception');
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+function listCollectionNames(database) {
+  const r = database.runCommand({ listCollections: 1, nameOnly: true });
+  if (r.ok !== 1) throw new Error('listCollections failed: ' + JSON.stringify(r));
+  return r.cursor.firstBatch.map((c) => c.name).sort();
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// createCollection / listCollections / drop
+// ---------------------------------------------------------------------------
+
+check('createCollection creates an empty collection', () => {
+  const r = testDb.runCommand({ create: 'plain_collection' });
+  assertEq(r.ok, 1, 'create ok');
+  const names = listCollectionNames(testDb);
+  assert(names.includes('plain_collection'),
+    'plain_collection should be listed: ' + JSON.stringify(names));
+});
+
+check('listCollections filter narrows to a single collection', () => {
+  testDb.another.insertOne({ _id: 1 });
+  const r = testDb.runCommand({
+    listCollections: 1,
+    filter: { name: 'plain_collection' },
+    nameOnly: true,
+  });
+  assertEq(r.ok, 1);
+  assertEq(r.cursor.firstBatch.length, 1);
+  assertEq(r.cursor.firstBatch[0].name, 'plain_collection');
+});
+
+check('drop removes a collection', () => {
+  testDb.to_be_dropped.insertOne({ _id: 1 });
+  const r = testDb.runCommand({ drop: 'to_be_dropped' });
+  assertEq(r.ok, 1, 'drop ok');
+  const names = listCollectionNames(testDb);
+  assert(!names.includes('to_be_dropped'),
+    'to_be_dropped should be gone: ' + JSON.stringify(names));
+});
+
+// ---------------------------------------------------------------------------
+// renameCollection
+// ---------------------------------------------------------------------------
+
+check('renameCollection moves data to a new name within the same db', () => {
+  const src = testDb.rename_src;
+  src.insertMany([{ _id: 1, v: 'a' }, { _id: 2, v: 'b' }]);
+  const r = db.adminCommand({
+    renameCollection: DB_NAME + '.rename_src',
+    to: DB_NAME + '.rename_dst',
+  });
+  assertEq(r.ok, 1, 'renameCollection ok');
+  const names = listCollectionNames(testDb);
+  assert(!names.includes('rename_src'), 'src should be gone');
+  assert(names.includes('rename_dst'), 'dst should be present');
+  assertEq(testDb.rename_dst.countDocuments({}), 2,
+    'documents should be preserved after rename');
+});
+
+// ---------------------------------------------------------------------------
+// Views
+// ---------------------------------------------------------------------------
+
+check('createView creates a queryable read-only view', () => {
+  const source = testDb.view_source;
+  source.insertMany([
+    { _id: 1, region: 'west', n: 1 },
+    { _id: 2, region: 'east', n: 2 },
+    { _id: 3, region: 'west', n: 3 },
+  ]);
+  const r = testDb.runCommand({
+    create: 'west_view',
+    viewOn: 'view_source',
+    pipeline: [{ $match: { region: 'west' } }],
+  });
+  assertEq(r.ok, 1, 'create view');
+});
+
+check('view returns the pipeline-filtered rows', () => {
+  const view = testDb.west_view;
+  const rows = view.find({}).toArray();
+  assertEq(rows.length, 2);
+  for (const row of rows) {
+    assertEq(row.region, 'west');
+  }
+});
+
+check('view shows up in listCollections with type:view', () => {
+  const r = testDb.runCommand({
+    listCollections: 1,
+    filter: { name: 'west_view' },
+  });
+  assertEq(r.ok, 1);
+  assertEq(r.cursor.firstBatch.length, 1);
+  assertEq(r.cursor.firstBatch[0].type, 'view');
+});
+
+check('drop removes the view', () => {
+  const r = testDb.runCommand({ drop: 'west_view' });
+  assertEq(r.ok, 1, 'drop view ok');
+  const names = listCollectionNames(testDb);
+  assert(!names.includes('west_view'), 'view should be removed');
+});
+
+// ---------------------------------------------------------------------------
+// dropDatabase
+// ---------------------------------------------------------------------------
+
+check('dropDatabase removes the entire database', () => {
+  const ephemeralName = DB_NAME + '_ephemeral';
+  const ephemeral = db.getSiblingDB(ephemeralName);
+  ephemeral.one.insertOne({ _id: 1 });
+  ephemeral.two.insertOne({ _id: 1 });
+  const r = ephemeral.runCommand({ dropDatabase: 1 });
+  assertEq(r.ok, 1, 'dropDatabase ok');
+  const admin = db.getSiblingDB('admin').runCommand({ listDatabases: 1 });
+  const names = admin.databases.map((x) => x.name);
+  assert(!names.includes(ephemeralName),
+    ephemeralName + ' should be removed: ' + JSON.stringify(names));
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/06-bson-types.js
+++ b/documentdb-local/integration-tests/tests/06-bson-types.js
@@ -1,0 +1,230 @@
+// Integration tests: BSON types.
+// Inserts and reads back representative values for every BSON type the
+// gateway exposes through mongosh, and verifies that the matching $type
+// query operator selects them. Types covered: ObjectId, String, Int32
+// (NumberInt), Int64 (NumberLong), Double, Decimal128 (NumberDecimal),
+// Boolean, Null, Array, EmbeddedDocument, Date, Timestamp, BinData,
+// Regex, MinKey, MaxKey.
+
+const TEST_FILE = '06-bson-types';
+const DB_NAME = 'it_06_bson_types';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertDeepEq(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error((msg || 'assertDeepEq') + ': expected ' + e + ', got ' + a);
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+const c = testDb.bson;
+const oid = new ObjectId();
+const fixedDate = new Date('2024-06-15T12:34:56.789Z');
+const ts = new Timestamp(1700000000, 1);
+const bin = new BinData(0, 'aGVsbG8=');                       // "hello"
+const regex = /^abc/i;
+const decimal = NumberDecimal('1234.5678');
+const int32 = NumberInt(42);
+const int64 = NumberLong('9007199254740993');                 // > 2^53
+
+c.insertMany([
+  { _id: 'oid',     v: oid,           probe: 'objectId' },
+  { _id: 'str',     v: 'hello',       probe: 'string' },
+  { _id: 'int32',   v: int32,         probe: 'int' },
+  { _id: 'int64',   v: int64,         probe: 'long' },
+  { _id: 'double',  v: 3.14159,       probe: 'double' },
+  { _id: 'decimal', v: decimal,       probe: 'decimal' },
+  { _id: 'bool',    v: true,          probe: 'bool' },
+  { _id: 'null',    v: null,          probe: 'null' },
+  { _id: 'array',   v: [1, 2, 3],     probe: 'array' },
+  { _id: 'object',  v: { a: 1, b: 2 }, probe: 'object' },
+  { _id: 'date',    v: fixedDate,     probe: 'date' },
+  { _id: 'ts',      v: ts,            probe: 'timestamp' },
+  { _id: 'bin',     v: bin,           probe: 'binData' },
+  { _id: 'regex',   v: regex,         probe: 'regex' },
+  { _id: 'minkey',  v: MinKey(),      probe: 'minKey' },
+  { _id: 'maxkey',  v: MaxKey(),      probe: 'maxKey' },
+]);
+
+// ---------------------------------------------------------------------------
+// Round-trip checks
+// ---------------------------------------------------------------------------
+
+check('ObjectId round-trips', () => {
+  const doc = c.findOne({ _id: 'oid' });
+  assert(doc.v instanceof ObjectId, 'v should be an ObjectId');
+  assertEq(doc.v.toHexString(), oid.toHexString());
+});
+
+check('String round-trips', () => {
+  assertEq(c.findOne({ _id: 'str' }).v, 'hello');
+});
+
+check('Int32 (NumberInt) round-trips and matches numerically', () => {
+  const doc = c.findOne({ _id: 'int32' });
+  assertEq(doc.v, 42);
+});
+
+check('Int64 (NumberLong) preserves precision beyond 2^53', () => {
+  const doc = c.findOne({ _id: 'int64' });
+  // NumberLong values stringify to their integer representation.
+  assertEq(String(doc.v), '9007199254740993');
+});
+
+check('Double round-trips', () => {
+  assertEq(c.findOne({ _id: 'double' }).v, 3.14159);
+});
+
+check('Decimal128 (NumberDecimal) round-trips', () => {
+  const doc = c.findOne({ _id: 'decimal' });
+  assertEq(doc.v.toString(), '1234.5678');
+});
+
+check('Boolean round-trips', () => {
+  assertEq(c.findOne({ _id: 'bool' }).v, true);
+});
+
+check('Null round-trips and matches with {field: null}', () => {
+  const doc = c.findOne({ _id: 'null' });
+  assertEq(doc.v, null);
+});
+
+check('Array round-trips', () => {
+  assertDeepEq(c.findOne({ _id: 'array' }).v, [1, 2, 3]);
+});
+
+check('EmbeddedDocument round-trips', () => {
+  assertDeepEq(c.findOne({ _id: 'object' }).v, { a: 1, b: 2 });
+});
+
+check('Date round-trips to the same instant', () => {
+  const doc = c.findOne({ _id: 'date' });
+  assert(doc.v instanceof Date, 'v should be a Date');
+  assertEq(doc.v.toISOString(), fixedDate.toISOString());
+});
+
+check('Timestamp round-trips with t and i', () => {
+  const doc = c.findOne({ _id: 'ts' });
+  assertEq(doc.v.t, 1700000000);
+  assertEq(doc.v.i, 1);
+});
+
+check('BinData round-trips with subtype 0', () => {
+  const doc = c.findOne({ _id: 'bin' });
+  // mongosh 8 / BSON 6 surfaces BinData as a Binary object: subtype is the
+  // .sub_type property (not a callable .subtype() method) and the value is
+  // not necessarily an `instanceof BinData` literal. We accept either shape
+  // by reading whichever accessor is present.
+  let subtype;
+  if (doc.v && typeof doc.v.sub_type === 'number') {
+    subtype = doc.v.sub_type;
+  } else if (doc.v && typeof doc.v.subtype === 'function') {
+    subtype = doc.v.subtype();
+  } else {
+    throw new Error('v is not a BinData/Binary: ' + JSON.stringify(doc.v));
+  }
+  assertEq(subtype, 0, 'subtype 0');
+});
+
+check('Regex literal round-trips with source and flags', () => {
+  const doc = c.findOne({ _id: 'regex' });
+  // DocumentDB returns a BSON regex which mongosh may surface either as a
+  // native JS RegExp or as a BSONRegExp wrapper with .pattern/.options.
+  let pattern;
+  let flags;
+  if (doc.v instanceof RegExp) {
+    pattern = doc.v.source;
+    flags = doc.v.flags;
+  } else if (doc.v && typeof doc.v.pattern === 'string') {
+    pattern = doc.v.pattern;
+    flags = typeof doc.v.options === 'string' ? doc.v.options : '';
+  } else {
+    throw new Error('v is not a Regex/BSONRegExp: ' + JSON.stringify(doc.v));
+  }
+  assertEq(pattern, '^abc', 'pattern');
+  assert(flags.includes('i'), 'i flag should be preserved (flags=' + flags + ')');
+});
+
+check('MinKey and MaxKey round-trip and sort to the extremes', () => {
+  // Use a sort to verify that MinKey sorts before everything and MaxKey
+  // after everything.
+  const cAll = testDb.minmax_sort;
+  cAll.insertMany([
+    { _id: 'a', v: MaxKey() },
+    { _id: 'b', v: 'middle' },
+    { _id: 'c', v: MinKey() },
+  ]);
+  const sorted = cAll.find({}).sort({ v: 1 }).toArray();
+  assertEq(sorted[0]._id, 'c', 'MinKey sorts first');
+  assertEq(sorted[2]._id, 'a', 'MaxKey sorts last');
+});
+
+// ---------------------------------------------------------------------------
+// $type queries (use BSON type-alias strings)
+// ---------------------------------------------------------------------------
+
+const typeProbes = [
+  ['objectId', 'oid'],
+  ['string',   'str'],
+  ['int',      'int32'],
+  ['long',     'int64'],
+  ['double',   'double'],
+  ['decimal',  'decimal'],
+  ['bool',     'bool'],
+  ['null',     'null'],
+  ['array',    'array'],
+  ['object',   'object'],
+  ['date',     'date'],
+  ['timestamp','ts'],
+  ['binData',  'bin'],
+  ['regex',    'regex'],
+  ['minKey',   'minkey'],
+  ['maxKey',   'maxkey'],
+];
+
+for (const [typeName, expectedId] of typeProbes) {
+  check('$type "' + typeName + '" selects the ' + expectedId + ' doc', () => {
+    const found = c.find({ v: { $type: typeName } }, { _id: 1 }).toArray()
+      .map((d) => d._id);
+    assert(found.includes(expectedId),
+      typeName + ' query should include ' + expectedId + ', got: ' +
+        JSON.stringify(found));
+  });
+}
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/07-cursors-and-projection.js
+++ b/documentdb-local/integration-tests/tests/07-cursors-and-projection.js
@@ -1,0 +1,195 @@
+// Integration tests: cursors and projection.
+// Covers projection forms (inclusion, exclusion, $slice, $elemMatch),
+// the find->getMore loop driven by batchSize, cursor iteration with
+// hasNext/next, sort+skip+limit ordering, and explicit cursor close.
+
+const TEST_FILE = '07-cursors-and-projection';
+const DB_NAME = 'it_07_cursors_and_projection';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertDeepEq(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error((msg || 'assertDeepEq') + ': expected ' + e + ', got ' + a);
+  }
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// Projection: inclusion, exclusion, computed
+// ---------------------------------------------------------------------------
+
+const proj = testDb.proj;
+proj.insertMany([
+  { _id: 1, name: 'alice', age: 30, city: 'Seattle', tags: ['a', 'b', 'c'] },
+  { _id: 2, name: 'bob',   age: 25, city: 'Portland', tags: ['c', 'd'] },
+]);
+
+check('projection inclusion returns only specified fields (+ _id)', () => {
+  const doc = proj.findOne({ _id: 1 }, { name: 1 });
+  assertDeepEq(Object.keys(doc).sort(), ['_id', 'name']);
+  assertEq(doc.name, 'alice');
+});
+
+check('projection inclusion can suppress _id with _id:0', () => {
+  const doc = proj.findOne({ _id: 1 }, { _id: 0, name: 1 });
+  assertDeepEq(Object.keys(doc).sort(), ['name']);
+});
+
+check('projection exclusion drops only specified fields', () => {
+  const doc = proj.findOne({ _id: 1 }, { city: 0, tags: 0 });
+  assertDeepEq(Object.keys(doc).sort(), ['_id', 'age', 'name']);
+});
+
+// ---------------------------------------------------------------------------
+// Array projection operators
+// ---------------------------------------------------------------------------
+
+check('$slice in projection takes the first N elements', () => {
+  const doc = proj.findOne({ _id: 1 }, { tags: { $slice: 2 }, _id: 0, name: 1 });
+  assertDeepEq(doc.tags, ['a', 'b']);
+});
+
+check('$slice with negative N takes the last elements', () => {
+  const doc = proj.findOne({ _id: 1 }, { tags: { $slice: -1 }, _id: 0 });
+  assertDeepEq(doc.tags, ['c']);
+});
+
+check('$slice with [skip, limit] takes a window', () => {
+  const doc = proj.findOne({ _id: 1 }, { tags: { $slice: [1, 1] }, _id: 0 });
+  assertDeepEq(doc.tags, ['b']);
+});
+
+check('$elemMatch projection returns the first matching array element', () => {
+  const c = testDb.elem_proj;
+  c.insertOne({
+    _id: 1,
+    scores: [{ s: 70, t: 'a' }, { s: 95, t: 'b' }, { s: 85, t: 'c' }],
+  });
+  const doc = c.findOne(
+    { _id: 1 },
+    { scores: { $elemMatch: { s: { $gt: 90 } } }, _id: 0 },
+  );
+  assertEq(doc.scores.length, 1);
+  assertEq(doc.scores[0].t, 'b');
+});
+
+// ---------------------------------------------------------------------------
+// sort + skip + limit interaction
+// ---------------------------------------------------------------------------
+
+check('sort + skip + limit returns the expected window', () => {
+  const c = testDb.window;
+  c.insertMany([
+    { _id: 1, n: 30 },
+    { _id: 2, n: 10 },
+    { _id: 3, n: 20 },
+    { _id: 4, n: 50 },
+    { _id: 5, n: 40 },
+  ]);
+  const r = c.find({}, { _id: 0, n: 1 })
+    .sort({ n: 1 }).skip(1).limit(2).toArray();
+  assertDeepEq(r.map((x) => x.n), [20, 30]);
+});
+
+check('descending sort works', () => {
+  const c = testDb.window;
+  const r = c.find({}, { _id: 0, n: 1 })
+    .sort({ n: -1 }).limit(2).toArray();
+  assertDeepEq(r.map((x) => x.n), [50, 40]);
+});
+
+// ---------------------------------------------------------------------------
+// Cursor iteration: hasNext / next, batchSize-driven getMore
+// ---------------------------------------------------------------------------
+
+check('hasNext / next iterate every document', () => {
+  const c = testDb.iter;
+  for (let i = 1; i <= 25; i++) c.insertOne({ _id: i });
+  const cursor = c.find({}).sort({ _id: 1 });
+  const ids = [];
+  while (cursor.hasNext()) ids.push(cursor.next()._id);
+  assertEq(ids.length, 25);
+  assertEq(ids[0], 1);
+  assertEq(ids[24], 25);
+});
+
+check('batchSize forces getMore to fetch all 100 docs', () => {
+  const c = testDb.batched;
+  const docs = [];
+  for (let i = 1; i <= 100; i++) docs.push({ _id: i, n: i });
+  c.insertMany(docs);
+
+  const cursor = c.find({}).batchSize(7).sort({ _id: 1 });
+  let count = 0;
+  while (cursor.hasNext()) {
+    cursor.next();
+    count++;
+  }
+  assertEq(count, 100,
+    'all docs must be fetched across multiple batches');
+});
+
+check('toArray returns the full result set', () => {
+  const c = testDb.batched;
+  const all = c.find({}).toArray();
+  assertEq(all.length, 100);
+});
+
+check('forEach visits every document exactly once', () => {
+  const c = testDb.batched;
+  let total = 0;
+  c.find({}, { _id: 0, n: 1 }).forEach((d) => { total += d.n; });
+  // Sum 1..100 = 5050
+  assertEq(total, 5050);
+});
+
+// ---------------------------------------------------------------------------
+// Cursor close
+// ---------------------------------------------------------------------------
+
+check('cursor.close() succeeds even before iteration is complete', () => {
+  const c = testDb.batched;
+  const cursor = c.find({}).batchSize(5);
+  cursor.next();
+  cursor.close();
+  // After close, additional next() calls should not blow up the test
+  // process; we just assert close() did not throw.
+  assert(true, 'cursor.close did not throw');
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}

--- a/documentdb-local/integration-tests/tests/08-error-handling.js
+++ b/documentdb-local/integration-tests/tests/08-error-handling.js
@@ -1,0 +1,170 @@
+// Integration tests: error handling.
+// Verifies that the gateway returns proper errors for the most common
+// misuse patterns: duplicate-key on a unique index, schema-validator
+// rejection, invalid update specifications, unknown commands, and ops
+// against missing collections / databases.
+
+const TEST_FILE = '08-error-handling';
+const DB_NAME = 'it_08_error_handling';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+function assertEq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error((msg || 'assertEq') + ': expected ' +
+      JSON.stringify(expected) + ', got ' + JSON.stringify(actual));
+  }
+}
+function assertThrows(fn, msg) {
+  let threw = false;
+  let captured;
+  try { fn(); } catch (e) { threw = true; captured = e; }
+  if (!threw) throw new Error((msg || 'assertThrows') + ': expected an exception');
+  return captured;
+}
+
+let _passed = 0;
+let _failed = 0;
+const _failures = [];
+function check(name, fn) {
+  try {
+    fn();
+    _passed++;
+    print('  PASS  ' + name);
+  } catch (e) {
+    _failed++;
+    _failures.push({ name: name, err: e.message });
+    print('  FAIL  ' + name + ': ' + e.message);
+  }
+}
+
+print('=== ' + TEST_FILE + ' ===');
+
+const testDb = db.getSiblingDB(DB_NAME);
+testDb.dropDatabase();
+
+// ---------------------------------------------------------------------------
+// Duplicate key on a unique index
+// ---------------------------------------------------------------------------
+
+check('duplicate insert into a unique index throws an error', () => {
+  const c = testDb.unique_kv;
+  c.createIndex({ k: 1 }, { name: 'k_unique', unique: true });
+  c.insertOne({ _id: 1, k: 'x' });
+
+  const err = assertThrows(
+    () => c.insertOne({ _id: 2, k: 'x' }),
+    'second insert with same k should be rejected',
+  );
+  // The error message in mongosh wraps the server response; we accept either
+  // the standard MongoDB phrasing or the underlying constraint name.
+  const m = (err && err.message) || '';
+  assert(
+    /duplicate key/i.test(m) || /unique/i.test(m) || /E11000/.test(m),
+    'expected a duplicate-key error, got: ' + m,
+  );
+  assertEq(c.countDocuments({}), 1, 'only the first insert should persist');
+});
+
+check('duplicate insert through insertMany aborts with ordered:true', () => {
+  const c = testDb.unique_ordered;
+  c.createIndex({ k: 1 }, { unique: true });
+  assertThrows(() => c.insertMany([
+    { _id: 1, k: 'a' },
+    { _id: 2, k: 'a' },   // dup
+    { _id: 3, k: 'b' },
+  ], { ordered: true }));
+  // With ordered:true execution stops at the failing element, so the third
+  // document is not inserted.
+  assertEq(c.countDocuments({}), 1);
+});
+
+// ---------------------------------------------------------------------------
+// Invalid update operator usage
+// ---------------------------------------------------------------------------
+
+check('top-level field name starting with $ in an update is rejected', () => {
+  const c = testDb.upd_invalid;
+  c.insertOne({ _id: 1, v: 'old' });
+  // Replacement documents cannot contain top-level $-prefixed names; this is
+  // distinct from an update operator document which would look like {$set: ...}.
+  assertThrows(
+    () => c.replaceOne({ _id: 1 }, { $weird: 'x' }),
+    'replaceOne with $-prefixed field should be rejected',
+  );
+});
+
+check('unknown update operator is rejected', () => {
+  const c = testDb.upd_unknown;
+  c.insertOne({ _id: 1, v: 'old' });
+  assertThrows(
+    () => c.updateOne({ _id: 1 }, { $totallyMadeUp: { v: 'x' } }),
+    'updateOne with an unknown operator should be rejected',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Unknown command
+// ---------------------------------------------------------------------------
+
+check('unknown command is reported as an error', () => {
+  // mongosh exposes server errors here in two shapes: either by throwing, or
+  // by returning {ok: 0, errmsg: ...}. Both are acceptable signals that the
+  // command was rejected. The only outcome we reject is a silent ok: 1.
+  let response = null;
+  let threwMsg = null;
+  try {
+    response = testDb.runCommand({ thisIsNotARealCommand: 1 });
+  } catch (e) {
+    threwMsg = e.message || String(e);
+  }
+  if (threwMsg !== null) {
+    assert(threwMsg.length > 0, 'thrown error should have a message');
+    return;
+  }
+  assertEq(response.ok, 0, 'ok should be 0');
+  assert(typeof response.errmsg === 'string' && response.errmsg.length > 0,
+    'errmsg should be a non-empty string: ' + JSON.stringify(response));
+});
+
+// ---------------------------------------------------------------------------
+// Operations against missing collections / databases
+// ---------------------------------------------------------------------------
+
+check('find on a missing collection returns an empty result', () => {
+  const r = testDb.never_created.find({}).toArray();
+  assertEq(r.length, 0);
+});
+
+check('countDocuments on a missing collection returns 0', () => {
+  assertEq(testDb.also_never_created.countDocuments({}), 0);
+});
+
+check('findOneAndUpdate without upsert on a missing doc returns null', () => {
+  const c = testDb.missing_doc;
+  c.insertOne({ _id: 1 });
+  const r = c.findOneAndUpdate({ _id: 999 }, { $set: { v: 'x' } });
+  assertEq(r, null, 'no match without upsert should return null');
+});
+
+check('drop on a missing collection is reported but does not crash', () => {
+  // Some servers return ok=0 with NamespaceNotFound, others return ok=1.
+  // Either is acceptable as long as the call completes and does not throw.
+  let outcome;
+  try {
+    outcome = testDb.runCommand({ drop: 'no_such_collection' });
+  } catch (e) {
+    outcome = { ok: 0, errmsg: e.message };
+  }
+  assert(outcome.ok === 0 || outcome.ok === 1,
+    'drop should return a structured response: ' + JSON.stringify(outcome));
+});
+
+testDb.dropDatabase();
+
+print('=== ' + TEST_FILE + ' summary: ' + _passed + ' passed, ' + _failed + ' failed ===');
+if (_failed > 0) {
+  for (const f of _failures) print('FAILURE: ' + f.name + ': ' + f.err);
+  quit(1);
+}


### PR DESCRIPTION
Adds an end-to-end image-level test suite for documentdb-local under
`documentdb-local/integration-tests/` and a new CI workflow
`.github/workflows/documentdb_local_image_tests.yml` that builds the
image and runs the suite on a PG 15/16/17/18 matrix.

### What runs in CI

| Job | Coverage |
| --- | --- |
| `build-image` | `packaging/build_packages.sh` + Dockerfile_documentdb_local, uploads per-PG artifact |
| `data-plane-tests` | every `tests/*.js` via `mongosh --file` (~167 `check(...)` assertions) |
| `auth-tests` | correct creds, wrong password, wrong user, unauthenticated, `--create-user false` |
| `tls-tests` | reuses existing `run_documentdb_local_tls_tests.sh` |
| `init-data-tests` | `--init-data true`, custom volume mount, `--skip-init-data`, invalid JS rejected |
| `persistence-tests` | restart container against shared `/data` volume |

### Test surface (data-plane)

Stays within the operator/command set already covered by the upstream
`functional-tests` allowlist, so the suite should be stable across all
four PG versions:

- `00-connectivity.js` — ping/hello/buildInfo/listDatabases/listCollections/dbStats/collStats/serverStatus/currentOp
- `01-crud.js` — insert/find/count/distinct + comparison/logical/element/regex/array operators + findOneAnd\*
- `02-update-operators.js` — `$set/$unset/$inc/$mul/$min/$max/$rename/$currentDate/$setOnInsert`, `$push/$pop/$pull/$pullAll/$addToSet` with `$each/$sort/$slice`, positional `$`/`$[]`
- `03-indexes.js` — single/compound/unique/sparse/partial/TTL/multikey + dropIndex variants
- `04-aggregation.js` — ~15 stages, accumulators, arithmetic/string/array/date/conditional expressions
- `05-collection-and-database.js` — create/list/drop/rename, validators, views, dropDatabase
- `06-bson-types.js` — every BSON type round-trip and `$type` selector
- `07-cursors-and-projection.js` — projection forms, batchSize+getMore, sort/skip/limit, hasNext/next
- `08-error-handling.js` — duplicate-key, validator rejection, invalid update operator, unknown command, ops on missing collections

### Local usage

```
./documentdb-local/integration-tests/run.sh --image documentdb-local:dev
./documentdb-local/integration-tests/run.sh --image documentdb-local:dev --only 03-indexes.js
./documentdb-local/integration-tests/scenarios/auth.sh        documentdb-local:dev
./documentdb-local/integration-tests/scenarios/init-data.sh   documentdb-local:dev
./documentdb-local/integration-tests/scenarios/persistence.sh documentdb-local:dev
```

### Validation

Pre-push checks were all clean: `actionlint`, `shellcheck`,
`node --check`, and `bash -n`.

See the commit message for the full file-by-file breakdown.